### PR TITLE
feat: additions to support using library in two-party protocols

### DIFF
--- a/crates/sl-paillier/Cargo.toml
+++ b/crates/sl-paillier/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 crypto-bigint = { version = "0.5.5", default-features = false, features = [
-  "alloc",
-  "serde",
   "rand_core",
 ] }
-crypto-primes = "0.5"
-rand_core = "0.6.4"
-serde = { version = "1.0", features = ["derive"] }
+crypto-primes = { version = "0.5", default_features = false }
+rand_core = { version = "0.6.4", default_features = false }
+serde = { version = "1.0", default-features = false, features = [
+  "derive",
+], optional = true }
 
 
 [dev-dependencies]
@@ -29,3 +29,7 @@ bincode = "1"
 [[bench]]
 name = "sl-paillier"
 harness = false
+
+[features]
+default = []
+serde = ["dep:serde", "crypto-bigint/serde"]

--- a/crates/sl-paillier/Cargo.toml
+++ b/crates/sl-paillier/Cargo.toml
@@ -6,9 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crypto-bigint = { version = "0.5.5", default-features = false, features = ["rand_core"] }
+crypto-bigint = { version = "0.5.5", default-features = false, features = [
+  "alloc",
+  "serde",
+  "rand_core",
+] }
 crypto-primes = "0.5"
 rand_core = "0.6.4"
+serde = { version = "1.0", features = ["derive"] }
+
 
 [dev-dependencies]
 lazy_static = "1.4"
@@ -17,6 +23,8 @@ rand = "0.8"
 criterion = "0.5"
 kzen-paillier = { version = "0.4.3" }
 curv-kzen = { version = "0.10.0" }
+serde_json = "1.0"
+bincode = "1"
 
 [[bench]]
 name = "sl-paillier"

--- a/crates/sl-paillier/benches/sl-paillier.rs
+++ b/crates/sl-paillier/benches/sl-paillier.rs
@@ -12,8 +12,8 @@ static Q: &str = "a80137484b2e0082dbcc520642ea0fcff5652a2367084c052c340b15f0c3ec
 static R: &str = "1a8b6c80c0cad628e4146e473d49b90b445d09e9a7934431c5cb3e7a43b162018e50b116ed8a0ebaf4b8907a18ad30edfbf573614ededd1bc763265be3a6eeef307d40c2431fa9970590fecd7c8af25d599b513749f998c1ba7a64caeedb2d5dd034f718b9efdf5cf62b129459134b257cf28c61bbe40fc4c20caec7c58b9fa4fa4aea0e2164a398a3c2a21cd012aee7bba3f502b9b10680a36e615d81ef690346d33c05966415c0bff5e6f856ca2bca5786947cca9adfd8300cbf0d2d6f0d4c848b21f46961443fb4519b8ee2dae018c586afe0ee0f430fde643e423cce0cf56f0a59baf6652b250ef6184ffcf09039d34e0a2e0d95c3b24295929e3db4d5f4";
 static M: &str = "1234567890abcdefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-type SK = sl_paillier::paillier::SK2048;
-type PK = sl_paillier::paillier::PK2048;
+type SK = sl_paillier::SK2048;
+type PK = sl_paillier::PK2048;
 
 fn from_hex<const L: usize>(h: &str) -> Uint<L> {
     let mut res = Uint::<L>::ZERO;

--- a/crates/sl-paillier/src/lib.rs
+++ b/crates/sl-paillier/src/lib.rs
@@ -45,21 +45,31 @@ where
 pub struct MinimalPK<const NN: usize, const N: usize>
 where
     Uint<N>: Bounded + Encoding,
-    Uint<NN>: Bounded + Encoding,
 {
     pub n: NonZero<Uint<N>>,
-    pub nn: Uint<NN>,
+}
+
+impl<const NN: usize, const N: usize> MinimalPK<NN, N>
+where
+    Uint<N>: Bounded + Encoding,
+    Uint<NN>: From<(Uint<N>, Uint<N>)>,
+{
+    pub fn compute_nn(&self) -> Uint<NN> {
+        self.n.square_wide().into()
+    }
 }
 
 impl<const NN: usize, const N: usize> From<MinimalPK<NN, N>> for PK<NN, N>
 where
     Uint<N>: Bounded + Encoding,
     Uint<NN>: Bounded + Encoding,
+    Uint<NN>: From<(Uint<N>, Uint<N>)>,
 {
     fn from(value: MinimalPK<NN, N>) -> Self {
+        let nn: Uint<NN> = value.n.square_wide().into();
         PK {
             n: value.n,
-            params: DynResidueParams::new(&value.nn),
+            params: DynResidueParams::new(&nn),
         }
     }
 }
@@ -507,10 +517,7 @@ where
         Uint<M>: Bounded + Encoding,
         Uint<C>: Bounded + Encoding,
     {
-        MinimalPK {
-            n: self.n,
-            nn: *self.params.modulus(),
-        }
+        MinimalPK { n: self.n }
     }
 
     pub fn get_n(&self) -> &NonZero<Uint<M>> {

--- a/crates/sl-paillier/src/lib.rs
+++ b/crates/sl-paillier/src/lib.rs
@@ -444,16 +444,16 @@ impl<const C: usize, const M: usize, const P: usize> Deref for SK<C, M, P> {
 
 pub fn decompose<const C: usize, const M: usize>(
     c: &Uint<C>,
-    m1: &Uint<M>,
-    m2: &Uint<M>,
+    p: &Uint<M>,
+    q: &Uint<M>,
 ) -> (Uint<M>, Uint<M>)
 where
     Uint<C>: Split<Output = Uint<M>>,
 {
     let (hi, lo) = c.split();
 
-    let cp: Uint<M> = Uint::const_rem_wide((lo, hi), m1).0;
-    let cq: Uint<M> = Uint::const_rem_wide((lo, hi), m2).0;
+    let cp: Uint<M> = Uint::const_rem_wide((lo, hi), p).0;
+    let cq: Uint<M> = Uint::const_rem_wide((lo, hi), q).0;
 
     (cp, cq)
 }

--- a/crates/sl-paillier/src/traits.rs
+++ b/crates/sl-paillier/src/traits.rs
@@ -4,23 +4,22 @@
 use rand_core::CryptoRngCore;
 
 use crypto_bigint::modular::runtime_mod::DynResidueParams;
-use crypto_bigint::{NonZero, RandomMod, Uint, Encoding};
+use crypto_bigint::{Encoding, NonZero, RandomMod, Uint};
 
 pub trait PublicN<const L: usize>
 where
-    Uint<L>: Encoding
+    Uint<L>: Encoding,
 {
     fn n(&self) -> &NonZero<Uint<L>>;
 
     fn r(&self, rng: &mut impl CryptoRngCore) -> NonZero<Uint<L>> {
         NonZero::new(Uint::<L>::random_mod(rng, &self.n())).unwrap()
     }
-
 }
 
 pub trait NN<const L: usize>
 where
-    Uint<L>: Encoding
+    Uint<L>: Encoding,
 {
     fn nn(&self) -> &NonZero<Uint<L>>;
 }


### PR DESCRIPTION
Changes:
- Add `extract_n_root` method (Used in NI Correct key proof)
- Add minimal versions of SK and PK for serialisation/communication purposes.
- Add serialization for SK, PK using the minimal versions. 
- Fix the `recombine` method. Fixes decrypt_fast failing bug.  

