### PR TITLE
chore: remove zeroize dep from sl-mpc-mate

### DIFF
--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -11,29 +11,34 @@ tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
 aead = { version = "0.5.2" }
 chacha20 = { version = "0.9" }
 chacha20poly1305 = { version = "0.10.1" }
-x25519-dalek = { version = "2.0.0", features = [ "static_secrets", "reusable_secrets", "zeroize" ] }
+x25519-dalek = { version = "2.0.0", features = [
+  "static_secrets",
+  "reusable_secrets",
+  "zeroize",
+] }
 ed25519-dalek = { version = "2.0.0" }
 sha2 = { version = "0.10" }
 rand = "0.8.5"
 rand_core = "0.6"
-elliptic-curve = { version ="0.13" }
-subtle = { version = "2.5", default-features = false, features = ["const-generics"] }
+elliptic-curve = { version = "0.13" }
+subtle = { version = "2.5", default-features = false, features = [
+  "const-generics",
+] }
 thiserror = "1.0.38"
-k256 = {version = "0.13", default-features = false, features = [ "arithmetic" ]}
+k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 derivation-path = "0.2.0"
 hmac = { version = "0.12.1" }
 base64 = "0.21.0"
 ripemd = "0.1.3"
 hex = "0.4.3"
 bs58 = "0.4.0"
-futures-util = { version = "0.3.0", features = [ "sink" ] }
+futures-util = { version = "0.3.0", features = ["sink"] }
 rayon = '1'
-zeroize = "1.6.1"
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "sync", "macros" ] }
+tokio = { version = "1", features = ["rt", "sync", "macros"] }
 
 [features]
-serde = [ "dep:serde", "elliptic-curve/arithmetic", "k256/serde" ]
-simple-relay = [ "dep:tokio" ]
+serde = ["dep:serde", "elliptic-curve/arithmetic", "k256/serde"]
+simple-relay = ["dep:tokio"]


### PR DESCRIPTION
# Motivation
zeroize dep of sl-mpc-mate was giving version issues when used alongside other dependency that used `zeroize = 1`. 

# Changes
While trying to fix it, I realized we don't need zeroize dep. 