### PR TITLE
Feat lambda c 128

### DIFF
--- a/crates/sl-oblivious/src/endemic_ot.rs
+++ b/crates/sl-oblivious/src/endemic_ot.rs
@@ -118,8 +118,14 @@ impl EndemicOTSender {
                 msg2.m_b_list[idx] = [m_b_0, m_b_1];
 
                 // check key generation
-                let rho_0 = h_function_2(idx, &t_b_0.diffie_hellman(&m_a_0).to_bytes());
-                let rho_1 = h_function_2(idx, &t_b_1.diffie_hellman(&m_a_1).to_bytes());
+                let rho_0 = h_function_2(
+                    idx,
+                    &t_b_0.diffie_hellman(&m_a_0).to_bytes(),
+                );
+                let rho_1 = h_function_2(
+                    idx,
+                    &t_b_1.diffie_hellman(&m_a_1).to_bytes(),
+                );
 
                 OneTimePadEncryptionKeys { rho_0, rho_1 }
             }),

--- a/crates/sl-oblivious/src/params.rs
+++ b/crates/sl-oblivious/src/params.rs
@@ -7,14 +7,14 @@ pub mod consts {
 
     // Computational security parameter, fixed to /lambda_c = 256
     // 256 OT seeds each 256-bit
-    pub const LAMBDA_C: usize = 256;
+    pub const LAMBDA_C: usize = 128;
 
     pub const LAMBDA_S: usize = 128;
 
     pub const S: usize = 128; // 16 bytes == 128 bits
 
     pub const L_BATCH: usize = 2;
-    pub const RHO: usize = 1;
+    pub const RHO: usize = 2;
     pub const SOFT_SPOKEN_K: usize = 4;
 
     // size of u8 array to hold LAMBDA_C bits.

--- a/crates/sl-oblivious/src/params.rs
+++ b/crates/sl-oblivious/src/params.rs
@@ -5,8 +5,8 @@ pub mod consts {
     // Bits on underlying Scalar
     pub const KAPPA: usize = 256;
 
-    // Computational security parameter, fixed to /lambda_c = 256
-    // 256 OT seeds each 256-bit
+    // Computational security parameter, fixed to /lambda_c = 128
+    // 128 OT seeds each 128-bit
     pub const LAMBDA_C: usize = 128;
 
     pub const LAMBDA_S: usize = 128;

--- a/crates/sl-oblivious/src/rvole.rs
+++ b/crates/sl-oblivious/src/rvole.rs
@@ -7,8 +7,8 @@
 //! xi = kappa + 2 * lambda_s
 //! kappa = |q| = 256
 //! lambda_s = 128
-//! lambda_c = 256
-//! l = 2, rho = 1, OT_WIDTH = l + rho = 3
+//! lambda_c = 128
+//! l = 2, rho = 2, OT_WIDTH = l + rho = 4
 
 use std::array;
 
@@ -59,7 +59,7 @@ fn generate_gadget_vec(session_id: &[u8]) -> impl Iterator<Item = Scalar> {
 pub struct RVOLEOutput {
     a_tilde: [[[u8; KAPPA_BYTES]; L_BATCH_PLUS_RHO]; XI],
     eta: [[u8; KAPPA_BYTES]; RHO],
-    mu_hash: [u8; 64],
+    mu_hash: [u8; 2 * LAMBDA_C_BYTES],
 }
 
 impl RVOLEOutput {
@@ -73,7 +73,7 @@ impl Default for RVOLEOutput {
         RVOLEOutput {
             a_tilde: [[[0u8; KAPPA_BYTES]; L_BATCH_PLUS_RHO]; XI],
             eta: [[0u8; KAPPA_BYTES]; RHO],
-            mu_hash: [0u8; 64],
+            mu_hash: [0u8; 2 * LAMBDA_C_BYTES],
         }
     }
 }
@@ -221,7 +221,7 @@ impl RVOLEReceiver {
             }
         }
 
-        let mut mu_prime_hash = [0u8; 64];
+        let mut mu_prime_hash = [0u8; 2 * LAMBDA_C_BYTES];
         t.challenge_bytes(b"mu-hash", &mut mu_prime_hash);
 
         if rvole_output.mu_hash.ct_ne(&mu_prime_hash).into() {


### PR DESCRIPTION
LAMBDA_C: 256 -> 128
RHO: 1 -> 2

The change makes DKS 2 times faster, but changes the format of messages (not a problem) and format of key share.
Dealing for key share must be addressed in dkls23 core crate before merging this PR.