### PR TITLE
Refactor sl-mpc-mate

### DIFF
--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -7,17 +7,7 @@ description = "Utilities for secure multi-party computation"
 publish = false
 
 [dependencies]
-generic-array = { version = "0.14.7" }
 tokio = { version = "1", features = ["rt", "sync", "time"], optional = true }
-aead = { version = "0.5.2" }
-chacha20 = { version = "0.9" }
-chacha20poly1305 = { version = "0.10.1" }
-x25519-dalek = { version = "2.0.0", features = [
-  "static_secrets",
-  "reusable_secrets",
-  "zeroize",
-] }
-ed25519-dalek = { version = "2.0.0" }
 sha2 = { version = "0.10" }
 rand = "0.8.5"
 rand_core = "0.6"

--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0.38"
 k256 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 derivation-path = "0.2.0"
 hmac = { version = "0.12.1" }
-base64 = "0.21.0"
+base64 = "0.22"
 ripemd = "0.1.3"
 hex = "0.4.3"
 bs58 = "0.4.0"

--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -24,7 +24,7 @@ ripemd = "0.1.3"
 hex = "0.4.3"
 bs58 = "0.4.0"
 futures-util = { version = "0.3.0", features = ["sink"] }
-rayon = '1'
+rayon = { version = "1", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -26,6 +26,8 @@ bs58 = "0.4.0"
 futures-util = { version = "0.3.0", features = ["sink"] }
 rayon = { version = "1", optional = true }
 serde = { version = "1", optional = true }
+bytemuck = { version = "1.14.1", features = [ "derive", "min_const_generics", "extern_crate_alloc" ] }
+zeroize = { version = "1.6", features = [ "derive" ] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "sync", "macros"] }

--- a/crates/sl-mpc-mate/src/coord.rs
+++ b/crates/sl-mpc-mate/src/coord.rs
@@ -18,11 +18,12 @@ pub use simple::SimpleMessageRelay;
 
 pub use buffered::BufferedMsgRelay;
 
+#[derive(Debug, Copy, Clone)]
 pub struct MessageSendError;
 
 pub trait Relay:
     Stream<Item = Vec<u8>>
-    + Sink<Vec<u8>, Error = InvalidMessage>
+    + Sink<Vec<u8>, Error = MessageSendError>
     + Unpin
     + 'static
 {
@@ -31,7 +32,7 @@ pub trait Relay:
 impl<T> Relay for T
 where
     T: Stream<Item = Vec<u8>>,
-    T: Sink<Vec<u8>, Error = InvalidMessage>,
+    T: Sink<Vec<u8>, Error = MessageSendError>,
     T: Unpin,
     T: 'static,
 {

--- a/crates/sl-mpc-mate/src/coord.rs
+++ b/crates/sl-mpc-mate/src/coord.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
+use std::future::Future;
+
 pub use futures_util::{Sink, SinkExt, Stream, StreamExt};
 
 use crate::message::*;
@@ -38,6 +40,8 @@ where
 {
 }
 
-pub trait MessageRelayService<R: Relay> {
-    fn connect(&self) -> R;
+pub trait MessageRelayService {
+    type MessageRelay: Relay;
+
+    fn connect(&self) -> impl Future<Output = Option<Self::MessageRelay>>;
 }

--- a/crates/sl-mpc-mate/src/coord.rs
+++ b/crates/sl-mpc-mate/src/coord.rs
@@ -29,7 +29,11 @@ pub struct MessageSendError;
 
 pub struct MaybeFeed<'a, S: ?Sized>(Option<Feed<'a, S, Vec<u8>>>);
 
-impl<Si: Sink<Vec<u8>> + Unpin> MaybeFeed<'_, Si> {
+impl<'a, Si: Sink<Vec<u8>> + Unpin> MaybeFeed<'a, Si> {
+    pub fn new(feed: Feed<'a, Si, Vec<u8>>) -> Self {
+        Self(Some(feed))
+    }
+
     pub fn skip() -> Self {
         Self(None)
     }
@@ -50,10 +54,7 @@ impl<Si: Sink<Vec<u8>> + Unpin> Future for MaybeFeed<'_, Si> {
 }
 
 pub trait Relay:
-    Stream<Item = Vec<u8>>
-    + Sink<Vec<u8>, Error = MessageSendError>
-    + Unpin
-    + 'static
+    Stream<Item = Vec<u8>> + Sink<Vec<u8>, Error = MessageSendError> + Unpin
 {
     fn ask(&mut self, id: &MsgId, ttl: u32) -> MaybeFeed<'_, Self> {
         MaybeFeed(Some(self.feed(AskMsg::allocate(id, ttl))))

--- a/crates/sl-mpc-mate/src/coord/adversary.rs
+++ b/crates/sl-mpc-mate/src/coord/adversary.rs
@@ -178,7 +178,7 @@ impl Stream for Connection {
 }
 
 impl Sink<Vec<u8>> for Connection {
-    type Error = InvalidMessage;
+    type Error = MessageSendError;
 
     fn poll_ready(
         self: Pin<&mut Self>,

--- a/crates/sl-mpc-mate/src/coord/adversary.rs
+++ b/crates/sl-mpc-mate/src/coord/adversary.rs
@@ -155,9 +155,11 @@ impl EvilMessageRelay {
     }
 }
 
-impl MessageRelayService<Connection> for EvilMessageRelay {
-    fn connect(&self) -> Connection {
-        Self::connect(self)
+impl MessageRelayService for EvilMessageRelay {
+    type MessageRelay = Connection;
+
+    async fn connect(&self) -> Option<Connection> {
+        Some(Self::connect(self))
     }
 }
 

--- a/crates/sl-mpc-mate/src/coord/adversary.rs
+++ b/crates/sl-mpc-mate/src/coord/adversary.rs
@@ -216,3 +216,5 @@ impl Sink<Vec<u8>> for Connection {
         Poll::Ready(Ok(()))
     }
 }
+
+impl Relay for Connection {}

--- a/crates/sl-mpc-mate/src/coord/simple.rs
+++ b/crates/sl-mpc-mate/src/coord/simple.rs
@@ -154,9 +154,11 @@ impl SimpleMessageRelay {
     }
 }
 
-impl MessageRelayService<MessageRelay> for SimpleMessageRelay {
-    fn connect(&self) -> MessageRelay {
-        Self::connect(self)
+impl MessageRelayService for SimpleMessageRelay {
+    type MessageRelay = MessageRelay;
+
+    async fn connect(&self) -> Option<Self::MessageRelay> {
+        Some(Self::connect(self))
     }
 }
 

--- a/crates/sl-mpc-mate/src/coord/simple.rs
+++ b/crates/sl-mpc-mate/src/coord/simple.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 
 pub use futures_util::{Sink, SinkExt, Stream, StreamExt};
 
-use crate::message::*;
+use crate::{coord::Relay, message::*};
 
 use super::{MessageRelayService, MessageSendError};
 
@@ -115,6 +115,8 @@ impl Sink<Vec<u8>> for MessageRelay {
         Poll::Ready(Ok(()))
     }
 }
+
+impl Relay for MessageRelay {}
 
 #[derive(Debug, Default)]
 pub struct SimpleMessageRelay {

--- a/crates/sl-mpc-mate/src/coord/simple.rs
+++ b/crates/sl-mpc-mate/src/coord/simple.rs
@@ -81,17 +81,18 @@ impl Sink<Vec<u8>> for MessageRelay {
     }
 
     fn start_send(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         item: Vec<u8>,
     ) -> Result<(), Self::Error> {
-        let this = &mut *self;
+        let this = self.get_mut();
 
-        let hdr = MsgHdr::from(&item).ok_or(MessageSendError)?;
+        let hdr: &MsgHdr =
+            item.as_slice().try_into().map_err(|_| MessageSendError)?;
 
         let mut inner = this.inner.lock().unwrap();
 
-        if hdr.kind == Kind::Ask {
-            if let Some(msg) = inner.recv(hdr.id, hdr.ttl, &this.tx) {
+        if item.len() == MESSAGE_HEADER_SIZE {
+            if let Some(msg) = inner.recv(*hdr.id(), hdr.ttl(), &this.tx) {
                 this.queue.push(msg);
             }
         } else {
@@ -178,42 +179,44 @@ impl Inner {
         }
     }
 
-    fn cleanup_later(&mut self, id: MsgId, expire: Instant, kind: Kind) {
-        self.expire.push(Expire(expire, id, kind));
+    fn cleanup_later(&mut self, id: &MsgId, expire: Instant, kind: Kind) {
+        self.expire.push(Expire(expire, *id, kind));
     }
 
     fn cleanup(&mut self, now: Instant) {
-        while let Some(ent) = self.expire.peek() {
-            if ent.0 > now {
+        while let Some(Expire(when, id, kind)) = self.expire.peek() {
+            if *when > now {
                 break;
             }
 
-            let Expire(_, id, kind) = self.expire.pop().unwrap();
-
-            if let Entry::Occupied(ocp) = self.messages.entry(id) {
-                match ocp.get() {
-                    MsgEntry::Ready(_) => {
-                        if kind == Kind::Pub {
-                            ocp.remove();
-                        }
-                    }
+            if let Entry::Occupied(ocp) = self.messages.entry(*id) {
+                if match ocp.get() {
+                    MsgEntry::Ready(_) => kind == &Kind::Pub,
 
                     MsgEntry::Waiters((expire, _)) => {
-                        if kind == Kind::Ask && *expire <= now {
-                            ocp.remove();
-                        }
+                        kind == &Kind::Ask && *expire <= now
                     }
+                } {
+                    ocp.remove();
                 }
             }
+
+            self.expire.pop();
         }
     }
 
     pub fn send(&mut self, msg: Vec<u8>) {
-        let MsgHdr { id, ttl, kind } = MsgHdr::from(&msg).unwrap();
-        let now = Instant::now();
-        let expire = now + ttl;
+        assert!(msg.len() > MESSAGE_HEADER_SIZE);
 
-        assert!(kind == Kind::Pub);
+        let hdr: &MsgHdr = msg.as_slice().try_into().unwrap();
+        let now = Instant::now();
+        let expire = now + hdr.ttl();
+        let id = *hdr.id();
+        let kind = if msg.len() == MESSAGE_HEADER_SIZE {
+            Kind::Ask
+        } else {
+            Kind::Pub
+        };
 
         // we have a locked state, let's cleanup some old entries
         self.cleanup(now);
@@ -232,7 +235,7 @@ impl Inner {
                     ocp.insert(MsgEntry::Ready(msg));
 
                     // remember to cleanup this entry later
-                    self.cleanup_later(id, expire, kind);
+                    self.cleanup_later(&id, expire, kind);
                 }
                 MsgEntry::Ready(_) => {
                     // ignore dups
@@ -242,7 +245,7 @@ impl Inner {
             Entry::Vacant(vac) => {
                 vac.insert(MsgEntry::Ready(msg));
 
-                self.cleanup_later(id, expire, kind);
+                self.cleanup_later(&id, expire, kind);
             }
         }
     }
@@ -273,7 +276,7 @@ impl Inner {
                         b.push(tx.clone());
 
                         // remember to cleanup this entry later
-                        self.cleanup_later(id, expire, Kind::Ask);
+                        self.cleanup_later(&id, expire, Kind::Ask);
                     }
                 }
             }
@@ -282,7 +285,7 @@ impl Inner {
                 // This is the first ASK for the message
                 vac.insert(MsgEntry::Waiters((expire, vec![tx.clone()])));
 
-                self.cleanup_later(id, expire, Kind::Ask);
+                self.cleanup_later(&id, expire, Kind::Ask);
             }
         }
 
@@ -321,7 +324,7 @@ mod tests {
             MessageTag::tag(0),
         );
 
-        let msg_to_send = allocate_message(&msg_id, 10, &[0; 5]);
+        let msg_to_send = allocate_message(&msg_id, 10, 0, &[0; 5]);
         c1.send(msg_to_send.clone()).await.unwrap();
 
         let mut c2 = coord.connect();

--- a/crates/sl-mpc-mate/src/coord/stats.rs
+++ b/crates/sl-mpc-mate/src/coord/stats.rs
@@ -127,6 +127,8 @@ impl<R: Relay> Sink<Vec<u8>> for RelayStats<R> {
     }
 }
 
+impl<R: Relay> Relay for RelayStats<R> {}
+
 impl<R: Relay> Deref for RelayStats<R> {
     type Target = R;
 

--- a/crates/sl-mpc-mate/src/coord/stats.rs
+++ b/crates/sl-mpc-mate/src/coord/stats.rs
@@ -51,13 +51,15 @@ impl<R: Relay> Stream for RelayStats<R> {
     type Item = <R as Stream>::Item;
 
     fn poll_next(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        match self.relay.poll_next_unpin(cx) {
+        let this = self.get_mut();
+
+        match this.relay.poll_next_unpin(cx) {
             Poll::Ready(Some(msg)) => {
-                let waiting = self.waiting.take();
-                let mut stats = self.stats.lock().unwrap();
+                let waiting = this.waiting.take();
+                let mut stats = this.stats.lock().unwrap();
 
                 stats.recv_size += msg.len();
                 stats.recv_count += 1;
@@ -66,8 +68,8 @@ impl<R: Relay> Stream for RelayStats<R> {
                     .map(|start| start.elapsed())
                     .unwrap_or(Duration::new(0, 0));
 
-                if let Some(hdr) = MsgHdr::from(&msg) {
-                    stats.wait_times.push((hdr.id, wait_time));
+                if let Ok(hdr) = <&MsgHdr>::try_from(msg.as_slice()) {
+                    stats.wait_times.push((*hdr.id(), wait_time));
                 }
 
                 stats.wait_time += wait_time;
@@ -78,8 +80,9 @@ impl<R: Relay> Stream for RelayStats<R> {
             Poll::Ready(None) => Poll::Ready(None),
 
             Poll::Pending => {
-                if self.waiting.is_none() {
-                    self.waiting = Some(Instant::now());
+                if this.waiting.is_none() {
+                    // mark the beginning of message waiting
+                    this.waiting = Some(Instant::now());
                 }
 
                 Poll::Pending
@@ -92,38 +95,36 @@ impl<R: Relay> Sink<Vec<u8>> for RelayStats<R> {
     type Error = <R as Sink<Vec<u8>>>::Error;
 
     fn poll_ready(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.relay.poll_ready_unpin(cx)
+        self.get_mut().relay.poll_ready_unpin(cx)
     }
 
     fn start_send(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         item: Vec<u8>,
     ) -> Result<(), Self::Error> {
-        let mut stats = self.stats.lock().unwrap();
+        let _ = self.stats.lock().map(|mut stats| {
+            stats.send_size += item.len();
+            stats.send_count += 1;
+        });
 
-        stats.send_size += item.len();
-        stats.send_count += 1;
-
-        drop(stats);
-
-        self.relay.start_send_unpin(item)
+        self.get_mut().relay.start_send_unpin(item)
     }
 
     fn poll_flush(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.relay.poll_flush_unpin(cx)
+        self.get_mut().relay.poll_flush_unpin(cx)
     }
 
     fn poll_close(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        self.relay.poll_close_unpin(cx)
+        self.get_mut().relay.poll_close_unpin(cx)
     }
 }
 

--- a/crates/sl-mpc-mate/src/matrix.rs
+++ b/crates/sl-mpc-mate/src/matrix.rs
@@ -34,12 +34,14 @@ fn transpose<C: CurveArithmetic>(
     let len = v[0].len();
 
     for n in 0..len - 1 {
-        for m in n + 1..len {
-            let nm = &mut v[n][m] as *mut C::Scalar;
-            let mn = &mut v[m][n] as *mut C::Scalar;
+        // n < len-1 => n+1 < len
+        let (up, down) = v.split_at_mut(n + 1);
 
-            // SAFETY: n != m, so nm and mn always points to separate locations
-            unsafe { core::ptr::swap_nonoverlapping(nm, mn, 1) }
+        for m in n + 1..len {
+            let nm = &mut up[n][m]; // == &mut v[n][m]
+            let mn = &mut down[m - (n + 1)][n]; // == &mut v[m][n]
+
+            core::mem::swap(nm, mn);
         }
     }
 

--- a/crates/sl-mpc-mate/src/message.rs
+++ b/crates/sl-mpc-mate/src/message.rs
@@ -160,7 +160,7 @@ impl<'a> TryFrom<&'a [u8]> for MsgId {
 }
 
 // It is always possible to get MsgId from &MsgHdr
-impl<'a> From<&'a MsgHdr> for MsgId {
+impl From<&MsgHdr> for MsgId {
     fn from(value: &MsgHdr) -> Self {
         *value.id()
     }

--- a/crates/sl-mpc-mate/src/message.rs
+++ b/crates/sl-mpc-mate/src/message.rs
@@ -34,12 +34,12 @@ impl MessageTag {
 
     /// Define a family of tags indexed by some parameter.
     pub const fn tag1(tag: u32, param: u32) -> Self {
-        Self::tag(tag as u64 | param as u64 >> 32)
+        Self::tag(tag as u64 | ((param as u64) << 32))
     }
 
     /// Define a familty of tags indexed by pair of parameters.
     pub const fn tag2(tag: u32, param1: u16, param2: u16) -> Self {
-        Self::tag(tag as u64 | param1 as u64 >> 32 | param2 as u64 >> 48)
+        Self::tag(tag as u64 | (param1 as u64) << 32 | (param2 as u64) << 48)
     }
 
     /// Convert the tag to an array of bytes.
@@ -291,6 +291,30 @@ mod test {
 
         assert!(
             <&MsgHdr>::try_from(&data[..MESSAGE_HEADER_SIZE - 1]).is_err()
+        );
+    }
+
+    #[test]
+    fn msg_tags() {
+        let t1 = MessageTag::tag(0x1020304050607080);
+
+        assert_eq!(
+            t1.to_bytes(),
+            [0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10]
+        );
+
+        let t2 = MessageTag::tag1(0x10203040, 0xAABBCCDD);
+
+        assert_eq!(
+            t2.to_bytes(),
+            [0x40, 0x30, 0x20, 0x10, 0xDD, 0xCC, 0xBB, 0xAA]
+        );
+
+        let t3 = MessageTag::tag2(0x10203040, 0xEEFF, 0xDEAD);
+
+        assert_eq!(
+            t3.to_bytes(),
+            [0x40, 0x30, 0x20, 0x10, 0xFF, 0xEE, 0xAD, 0xDE]
         );
     }
 }

--- a/crates/sl-oblivious/src/constants.rs
+++ b/crates/sl-oblivious/src/constants.rs
@@ -44,3 +44,6 @@ pub const RANDOM_VOLE_THETA_LABEL: Label = Label::new(VERSION, 12);
 
 /// LABEL for RandomVOLE mu
 pub const RANDOM_VOLE_MU_LABEL: Label = Label::new(VERSION, 13);
+
+/// LABEL for baseOT in RandomVOLE OT variant
+pub const RANDOM_VOLE_BASE_OT: Label = Label::new(VERSION, 14);

--- a/crates/sl-oblivious/src/endemic_ot.rs
+++ b/crates/sl-oblivious/src/endemic_ot.rs
@@ -186,6 +186,7 @@ impl EndemicOTSender {
 /// EndemicOTReceiver
 /// 1 out of 2 Endemic OT Fig.8 https://eprint.iacr.org/2019/706.pdf
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(zeroize::Zeroize)]
 pub struct EndemicOTReceiver {
     packed_choice_bits: [u8; LAMBDA_C_BYTES],
     #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]

--- a/crates/sl-oblivious/src/endemic_ot.rs
+++ b/crates/sl-oblivious/src/endemic_ot.rs
@@ -188,7 +188,7 @@ impl EndemicOTSender {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(zeroize::Zeroize)]
 pub struct EndemicOTReceiver {
-    packed_choice_bits: [u8; LAMBDA_C_BYTES],
+    pub(crate) packed_choice_bits: [u8; LAMBDA_C_BYTES],
     #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
     t_a_list: [Scalar; LAMBDA_C],
 }

--- a/crates/sl-oblivious/src/lib.rs
+++ b/crates/sl-oblivious/src/lib.rs
@@ -127,3 +127,6 @@ pub mod utils {
 pub mod params;
 
 pub mod label;
+
+/// Random Vector OLE (base OT variant)
+pub mod rvole_ot_variant;

--- a/crates/sl-oblivious/src/rvole.rs
+++ b/crates/sl-oblivious/src/rvole.rs
@@ -78,7 +78,6 @@ impl Default for RVOLEOutput {
     }
 }
 
-///
 #[derive(Clone, Copy, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
 #[repr(C)]
 pub struct RVOLEReceiver {
@@ -87,7 +86,6 @@ pub struct RVOLEReceiver {
     receiver_extended_output: ReceiverExtendedOutput,
 }
 
-///
 impl RVOLEReceiver {
     /// Create a new RVOLE receiver
     pub fn new<R: CryptoRngCore>(
@@ -133,7 +131,6 @@ impl RVOLEReceiver {
 }
 
 impl RVOLEReceiver {
-    ///
     pub fn process(
         &self,
         rvole_output: &RVOLEOutput,
@@ -240,11 +237,9 @@ impl RVOLEReceiver {
     }
 }
 
-///
 pub struct RVOLESender;
 
 impl RVOLESender {
-    ///
     pub fn process<R: CryptoRngCore>(
         session_id: &[u8],
         seed_ot_results: &ReceiverOTSeed,

--- a/crates/sl-oblivious/src/rvole_ot_variant.rs
+++ b/crates/sl-oblivious/src/rvole_ot_variant.rs
@@ -1,0 +1,542 @@
+// Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
+// This software is licensed under the Silence Laboratories License Agreement.
+
+//! Implementation of the protocol 5.2 OT-Based Random Vector OLE
+//! https://eprint.iacr.org/2023/765.pdf
+//! with OT variant modification
+//!
+//! xi = kappa + 2 * lambda_s
+//! kappa = |q| = 256
+//! lambda_s = 128
+//! lambda_c = 256
+//! l = 2, rho = 1, OT_WIDTH = l + rho = 3
+
+use std::array;
+
+use merlin::Transcript;
+
+use k256::{
+    elliptic_curve::{
+        bigint::Encoding,
+        ops::Reduce,
+        rand_core::CryptoRngCore,
+        subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
+    },
+    Scalar, U256,
+};
+
+use crate::endemic_ot::{
+    EndemicOTMsg1, EndemicOTMsg2, EndemicOTReceiver, EndemicOTSender,
+};
+use crate::{
+    constants::{
+        RANDOM_VOLE_GADGET_VECTOR_LABEL, RANDOM_VOLE_MU_LABEL,
+        RANDOM_VOLE_THETA_LABEL,
+    },
+    params::consts::*,
+    utils::ExtractBit,
+};
+
+const XI: usize = L; // by definition
+const XI_BYTES: usize = XI >> 3;
+
+use crate::constants::{
+    RANDOM_VOLE_BASE_OT, SOFT_SPOKEN_LABEL, SOFT_SPOKEN_RANDOMIZE_LABEL,
+};
+use crate::soft_spoken::SenderExtendedOutput;
+
+fn generate_gadget_vec(session_id: &[u8]) -> impl Iterator<Item = Scalar> {
+    let mut t = Transcript::new(&RANDOM_VOLE_GADGET_VECTOR_LABEL);
+    t.append_message(b"session-id", session_id);
+
+    (0..XI).map(move |i| {
+        t.append_u64(b"index", i as u64);
+
+        let mut repr = [0u8; KAPPA_BYTES];
+        t.challenge_bytes(b"next value", &mut repr);
+
+        Scalar::reduce(U256::from_be_bytes(repr))
+    })
+}
+
+/// Message 1 output in RVOLE protocol
+#[derive(
+    Clone, Copy, bytemuck::AnyBitPattern, bytemuck::NoUninit, Default,
+)]
+#[repr(C)]
+pub struct RVOLEMsg1 {
+    ot_msg1_a: EndemicOTMsg1,
+    ot_msg1_b: EndemicOTMsg1,
+}
+
+/// Message 2 output in RVOLE protocol
+#[derive(Clone, Copy, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
+#[repr(C)]
+pub struct RVOLEMsg2 {
+    ot_msg2_a: EndemicOTMsg2,
+    ot_msg2_b: EndemicOTMsg2,
+    a_tilde: [[[u8; KAPPA_BYTES]; L_BATCH_PLUS_RHO]; XI],
+    eta: [[u8; KAPPA_BYTES]; RHO],
+    mu_hash: [u8; 64],
+}
+
+impl RVOLEMsg2 {
+    fn get_a_tilde(&self, j: usize, i: usize) -> Scalar {
+        Scalar::reduce(U256::from_be_bytes(self.a_tilde[j][i]))
+    }
+}
+
+impl Default for RVOLEMsg2 {
+    fn default() -> Self {
+        RVOLEMsg2 {
+            ot_msg2_a: EndemicOTMsg2::default(),
+            ot_msg2_b: EndemicOTMsg2::default(),
+            a_tilde: [[[0u8; KAPPA_BYTES]; L_BATCH_PLUS_RHO]; XI],
+            eta: [[0u8; KAPPA_BYTES]; RHO],
+            mu_hash: [0u8; 64],
+        }
+    }
+}
+
+///
+#[derive(Clone, Copy, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
+#[repr(C)]
+pub struct RVOLEReceiver {
+    session_id: [u8; 32],
+    beta: [u8; XI_BYTES],
+}
+
+///
+impl RVOLEReceiver {
+    /// Create a new RVOLE receiver
+    pub fn new<R: CryptoRngCore>(
+        session_id: [u8; 32],
+        rvole_output_1: &mut RVOLEMsg1,
+        rng: &mut R,
+    ) -> (
+        Box<RVOLEReceiver>,
+        Box<EndemicOTReceiver>,
+        Box<EndemicOTReceiver>,
+        Scalar,
+    ) {
+        let mut t = Transcript::new(&RANDOM_VOLE_BASE_OT);
+        t.append_message(b"session-id", &session_id);
+        let mut session_id_a = [0u8; 32];
+        let mut session_id_b = [0u8; 32];
+        t.challenge_bytes(b"session-id-a", &mut session_id_a);
+        t.challenge_bytes(b"session-id-b", &mut session_id_b);
+
+        let receiver_a = EndemicOTReceiver::new(
+            &session_id_a,
+            &mut rvole_output_1.ot_msg1_a,
+            rng,
+        );
+
+        let receiver_b = EndemicOTReceiver::new(
+            &session_id_b,
+            &mut rvole_output_1.ot_msg1_b,
+            rng,
+        );
+
+        let beta_a = receiver_a.packed_choice_bits;
+        let beta_b = receiver_b.packed_choice_bits;
+
+        assert_eq!(beta_a.len() + beta_b.len(), XI_BYTES);
+
+        let mut beta: [u8; XI_BYTES] = [0u8; XI_BYTES];
+        beta[0..XI_BYTES / 2].copy_from_slice(&beta_a);
+        beta[XI_BYTES / 2..XI_BYTES].copy_from_slice(&beta_b);
+
+        // b = <g, /beta>
+        let b = generate_gadget_vec(&session_id).enumerate().fold(
+            Scalar::ZERO,
+            |option_0, (i, gv)| {
+                let i_bit = beta.extract_bit(i);
+                let option_1 = option_0 + gv;
+
+                Scalar::conditional_select(
+                    &option_0,
+                    &option_1,
+                    Choice::from(i_bit as u8),
+                )
+            },
+        );
+
+        let mut next = bytemuck::allocation::zeroed_box::<RVOLEReceiver>();
+
+        next.session_id = session_id;
+        next.beta = beta;
+
+        (next, Box::new(receiver_a), Box::new(receiver_b), b)
+    }
+}
+
+impl RVOLEReceiver {
+    ///
+    pub fn process(
+        &self,
+        rvole_output_2: &RVOLEMsg2,
+        receiver_a: Box<EndemicOTReceiver>,
+        receiver_b: Box<EndemicOTReceiver>,
+    ) -> Result<[Scalar; L_BATCH], &'static str> {
+        let receiver_output_a =
+            receiver_a.process(&rvole_output_2.ot_msg2_a)?;
+        let receiver_output_b =
+            receiver_b.process(&rvole_output_2.ot_msg2_b)?;
+
+        assert_eq!(
+            receiver_output_a.otp_dec_keys.len()
+                + receiver_output_b.otp_dec_keys.len(),
+            XI
+        );
+
+        let mut v_x = bytemuck::allocation::zeroed_box::<
+            [[[u8; KAPPA_BYTES]; OT_WIDTH]; XI],
+        >();
+
+        for j in 0..XI / 2 {
+            let mut t = Transcript::new(&SOFT_SPOKEN_LABEL);
+            t.append_message(b"session-id", &self.session_id);
+            t.append_u64(b"index", j as u64);
+            t.append_message(
+                &SOFT_SPOKEN_RANDOMIZE_LABEL,
+                &receiver_output_a.otp_dec_keys[j],
+            );
+            for k in &mut v_x[j] {
+                t.challenge_bytes(b"", k);
+            }
+        }
+        for j in XI / 2..XI {
+            let mut t = Transcript::new(&SOFT_SPOKEN_LABEL);
+            t.append_message(b"session-id", &self.session_id);
+            t.append_u64(b"index", j as u64);
+            t.append_message(
+                &SOFT_SPOKEN_RANDOMIZE_LABEL,
+                &receiver_output_b.otp_dec_keys[j - XI / 2],
+            );
+            for k in &mut v_x[j] {
+                t.challenge_bytes(b"", k);
+            }
+        }
+
+        let mut t = Transcript::new(&RANDOM_VOLE_THETA_LABEL);
+        t.append_message(b"session-id", &self.session_id);
+
+        for j in 0..XI {
+            t.append_u64(b"row of a tilde", j as u64);
+            for i in 0..L_BATCH_PLUS_RHO {
+                t.append_message(b"", &rvole_output_2.a_tilde[j][i]);
+            }
+        }
+
+        let mut theta = [[Scalar::ZERO; L_BATCH]; RHO];
+        #[allow(clippy::needless_range_loop)]
+        for k in 0..RHO {
+            for i in 0..L_BATCH {
+                t.append_u64(b"theta k", k as u64);
+                t.append_u64(b"theta i", i as u64);
+
+                let mut digest = [0u8; KAPPA_BYTES];
+                t.challenge_bytes(b"theta", digest.as_mut());
+                theta[k][i] = Scalar::reduce(U256::from_be_bytes(digest));
+            }
+        }
+
+        let mut d_dot = [[Scalar::ZERO; L_BATCH]; XI];
+        let mut d_hat = [[Scalar::ZERO; RHO]; XI];
+
+        for j in 0..XI {
+            let j_bit = self.beta.extract_bit(j);
+            for i in 0..L_BATCH {
+                let option_0 = Scalar::reduce(U256::from_be_bytes(v_x[j][i]));
+                let option_1 = option_0 + rvole_output_2.get_a_tilde(j, i);
+                let chosen = Scalar::conditional_select(
+                    &option_0,
+                    &option_1,
+                    Choice::from(j_bit as u8),
+                );
+                d_dot[j][i] = chosen
+            }
+            for k in 0..RHO {
+                let option_0 =
+                    Scalar::reduce(U256::from_be_bytes(v_x[j][L_BATCH + k]));
+                let option_1 =
+                    option_0 + rvole_output_2.get_a_tilde(j, L_BATCH + k);
+                let chosen = Scalar::conditional_select(
+                    &option_0,
+                    &option_1,
+                    Choice::from(j_bit as u8),
+                );
+                d_hat[j][k] = chosen
+            }
+        }
+
+        // mu_prime hash
+        let mut t = Transcript::new(&RANDOM_VOLE_MU_LABEL);
+        t.append_message(b"session-id", &self.session_id);
+
+        #[allow(clippy::needless_range_loop)]
+        for j in 0..XI {
+            let j_bit = self.beta.extract_bit(j);
+
+            for k in 0..RHO {
+                let mut v = d_hat[j][k];
+                for i in 0..L_BATCH {
+                    v += theta[k][i] * d_dot[j][i]
+                }
+
+                let option_0 = v;
+                let option_1 = option_0
+                    - Scalar::reduce(U256::from_be_bytes(
+                        rvole_output_2.eta[k],
+                    ));
+                let chosen = Scalar::conditional_select(
+                    &option_0,
+                    &option_1,
+                    Choice::from(j_bit as u8),
+                );
+                t.append_message(b"chosen", &chosen.to_bytes());
+            }
+        }
+
+        let mut mu_prime_hash = [0u8; 64];
+        t.challenge_bytes(b"mu-hash", &mut mu_prime_hash);
+
+        if rvole_output_2.mu_hash.ct_ne(&mu_prime_hash).into() {
+            return Err("Consistency check failed");
+        }
+
+        let mut d = [Scalar::ZERO; L_BATCH];
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..L_BATCH {
+            for (j, gv) in generate_gadget_vec(&self.session_id).enumerate() {
+                d[i] += gv * d_dot[j][i];
+            }
+        }
+
+        Ok(d)
+    }
+}
+
+///
+pub struct RVOLESender;
+
+impl RVOLESender {
+    ///
+    pub fn process<R: CryptoRngCore>(
+        session_id: &[u8],
+        a: &[Scalar; L_BATCH],
+        rvole_output_1: &RVOLEMsg1,
+        output: &mut RVOLEMsg2,
+        rng: &mut R,
+    ) -> Result<[Scalar; L_BATCH], &'static str> {
+        let mut t = Transcript::new(&RANDOM_VOLE_BASE_OT);
+        t.append_message(b"session-id", session_id);
+        let mut session_id_a = [0u8; 32];
+        let mut session_id_b = [0u8; 32];
+        t.challenge_bytes(b"session-id-a", &mut session_id_a);
+        t.challenge_bytes(b"session-id-b", &mut session_id_b);
+
+        let Ok(sender_ot_output_a) = EndemicOTSender::process(
+            &session_id_a,
+            &rvole_output_1.ot_msg1_a,
+            &mut output.ot_msg2_a,
+            rng,
+        ) else {
+            return Err("Base OT error");
+        };
+        let Ok(sender_ot_output_b) = EndemicOTSender::process(
+            &session_id_b,
+            &rvole_output_1.ot_msg1_b,
+            &mut output.ot_msg2_b,
+            rng,
+        ) else {
+            return Err("Base OT error");
+        };
+
+        assert_eq!(
+            sender_ot_output_a.otp_enc_keys.len()
+                + sender_ot_output_b.otp_enc_keys.len(),
+            XI
+        );
+
+        let mut sender_extended_output = SenderExtendedOutput::new();
+        let v_0 = &mut sender_extended_output.v_0;
+        let v_1 = &mut sender_extended_output.v_1;
+        for j in 0..XI / 2 {
+            let mut t = Transcript::new(&SOFT_SPOKEN_LABEL);
+            t.append_message(b"session-id", session_id);
+            t.append_u64(b"index", j as u64);
+            t.append_message(
+                &SOFT_SPOKEN_RANDOMIZE_LABEL,
+                &sender_ot_output_a.otp_enc_keys[j].rho_0,
+            );
+            for k in &mut v_0[j] {
+                t.challenge_bytes(b"", k);
+            }
+
+            let mut t = Transcript::new(&SOFT_SPOKEN_LABEL);
+            t.append_message(b"session-id", session_id);
+            t.append_u64(b"index", j as u64);
+            t.append_message(
+                &SOFT_SPOKEN_RANDOMIZE_LABEL,
+                &sender_ot_output_a.otp_enc_keys[j].rho_1,
+            );
+            for k in &mut v_1[j] {
+                t.challenge_bytes(b"", k);
+            }
+        }
+        for j in XI / 2..XI {
+            let mut t = Transcript::new(&SOFT_SPOKEN_LABEL);
+            t.append_message(b"session-id", session_id);
+            t.append_u64(b"index", j as u64);
+            t.append_message(
+                &SOFT_SPOKEN_RANDOMIZE_LABEL,
+                &sender_ot_output_b.otp_enc_keys[j - XI / 2].rho_0,
+            );
+            for k in &mut v_0[j] {
+                t.challenge_bytes(b"", k);
+            }
+
+            let mut t = Transcript::new(&SOFT_SPOKEN_LABEL);
+            t.append_message(b"session-id", session_id);
+            t.append_u64(b"index", j as u64);
+            t.append_message(
+                &SOFT_SPOKEN_RANDOMIZE_LABEL,
+                &sender_ot_output_b.otp_enc_keys[j - XI / 2].rho_1,
+            );
+            for k in &mut v_1[j] {
+                t.challenge_bytes(b"", k);
+            }
+        }
+
+        let alpha_0 = |j: usize, i: usize| {
+            Scalar::reduce(U256::from_be_bytes(
+                sender_extended_output.v_0[j][i],
+            ))
+        };
+
+        let alpha_1 = |j: usize, i: usize| {
+            Scalar::reduce(U256::from_be_bytes(
+                sender_extended_output.v_1[j][i],
+            ))
+        };
+
+        let c: [Scalar; L_BATCH] = array::from_fn(|i| {
+            generate_gadget_vec(session_id)
+                .enumerate()
+                .map(|(j, gv)| gv * alpha_0(j, i))
+                .sum::<Scalar>()
+                .negate()
+        });
+
+        output.eta.iter_mut().for_each(|eta| {
+            *eta = Scalar::generate_biased(rng).to_bytes().into();
+        });
+
+        let mut t = Transcript::new(&RANDOM_VOLE_THETA_LABEL);
+        t.append_message(b"session-id", session_id);
+
+        for (j, a_tilde_j_ref) in output.a_tilde.iter_mut().enumerate() {
+            t.append_u64(b"row of a tilde", j as u64);
+            for i in 0..L_BATCH {
+                let v = alpha_0(j, i) - alpha_1(j, i) + a[i];
+                a_tilde_j_ref[i] = v.to_bytes().into();
+
+                t.append_message(b"", &a_tilde_j_ref[i]);
+            }
+
+            for (k, eta) in output.eta.iter().enumerate() {
+                let v = alpha_0(j, L_BATCH + k) - alpha_1(j, L_BATCH + k)
+                    + Scalar::reduce(U256::from_be_bytes(*eta));
+                a_tilde_j_ref[L_BATCH + k] = v.to_bytes().into();
+
+                t.append_message(b"", &a_tilde_j_ref[L_BATCH + k]);
+            }
+        }
+
+        let mut theta = [[Scalar::ZERO; L_BATCH]; RHO];
+        #[allow(clippy::needless_range_loop)]
+        for k in 0..RHO {
+            for i in 0..L_BATCH {
+                t.append_u64(b"theta k", k as u64);
+                t.append_u64(b"theta i", i as u64);
+
+                let mut digest = [0u8; 32];
+                t.challenge_bytes(b"theta", &mut digest);
+
+                theta[k][i] = Scalar::reduce(U256::from_be_bytes(digest));
+            }
+        }
+
+        for (k, eta) in output.eta.iter_mut().enumerate() {
+            let mut s = Scalar::reduce(U256::from_be_bytes(*eta));
+            s += theta[k]
+                .iter()
+                .zip(a)
+                .map(|(t_k_i, a_i)| t_k_i * a_i)
+                .sum::<Scalar>();
+            *eta = s.to_bytes().into();
+        }
+
+        let mut t = Transcript::new(&RANDOM_VOLE_MU_LABEL);
+        t.append_message(b"session-id", session_id);
+
+        #[allow(clippy::needless_range_loop)]
+        for j in 0..XI {
+            for k in 0..RHO {
+                let mut v = alpha_0(j, L_BATCH + k);
+                for i in 0..L_BATCH {
+                    v += theta[k][i] * alpha_0(j, i)
+                }
+                t.append_message(b"chosen", &v.to_bytes());
+            }
+        }
+
+        t.challenge_bytes(b"mu-hash", &mut output.mu_hash);
+
+        Ok(c)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::prelude::*;
+
+    #[test]
+    fn pairwise_ot_variant() {
+        let mut rng = rand::thread_rng();
+
+        let session_id: [u8; 32] = rng.gen();
+
+        let mut round1_output = RVOLEMsg1::default();
+        let (receiver, ot_receiver_a, ot_receiver_b, beta) =
+            RVOLEReceiver::new(session_id, &mut round1_output, &mut rng);
+
+        let (alpha1, alpha2) = (
+            Scalar::generate_biased(&mut rng),
+            Scalar::generate_biased(&mut rng),
+        );
+
+        let mut round2_output = RVOLEMsg2::default();
+        let sender_shares = RVOLESender::process(
+            &session_id,
+            &[alpha1, alpha2],
+            &round1_output,
+            &mut round2_output,
+            &mut rng,
+        )
+        .unwrap();
+
+        let receiver_shares = receiver
+            .process(&round2_output, ot_receiver_a, ot_receiver_b)
+            .unwrap();
+
+        let sum_0 = receiver_shares[0] + sender_shares[0];
+        let sum_1 = receiver_shares[1] + sender_shares[1];
+
+        assert_eq!(sum_0, alpha1 * beta);
+        assert_eq!(sum_1, alpha2 * beta);
+    }
+}

--- a/crates/sl-oblivious/src/soft_spoken/mul_poly.rs
+++ b/crates/sl-oblivious/src/soft_spoken/mul_poly.rs
@@ -3,7 +3,7 @@
 
 ///     Multiplies `a` and `b` in the finite field of order 2^128
 ///     modulo the irreducible polynomial f(x) = 1 + x + x^2 + x^7 + x^128
-
+///
 ///     https://link.springer.com/book/10.1007/b97644
 ///     multiplication part: Algorithm 2.34, "Right-to-left comb method for polynomial multiplication"
 ///     reduction part: variant of the idea of Figure 2.9

--- a/crates/sl-oblivious/src/soft_spoken/soft_spoken_ot.rs
+++ b/crates/sl-oblivious/src/soft_spoken/soft_spoken_ot.rs
@@ -110,7 +110,6 @@ impl ReceiverExtendedOutput {
     }
 }
 
-///
 pub struct SoftSpokenOTReceiver;
 
 impl SoftSpokenOTReceiver {


### PR DESCRIPTION
- feat-ot-variant
- Replace message::InvalidMessage with coord::MessageSendError
- Remove message::NonceCounter
- Remove reexport of ed25519_dalek x25519_dalek types
- Remove unsafe code
- Remove unused deps
- Generalized `factorial_range()`. It works for any PrimeField now
  instead of U256 as before.
- Make table of recomputed factorials in range 0..20
- Factor out `polynomial_coeff_multipliers_iter()` from
  `polynomial_coeff_multipliers()` and rewrote it to avoid
  writing to result vector twice
- add tests