### PR TITLE
SL-872

### DIFF
--- a/crates/sl-oblivious/Cargo.toml
+++ b/crates/sl-oblivious/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sl-oblivious"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/sl-oblivious/Cargo.toml
+++ b/crates/sl-oblivious/Cargo.toml
@@ -11,11 +11,10 @@ elliptic-curve = { version ="0.13" }
 k256 = { version = "0.13", default-features = false, features = [ "arithmetic" ]}
 rand = "0.8"
 rayon = "1"
-x25519-dalek = { version = "2.0.0", features = [ "static_secrets", "zeroize" ] }
 zeroize = "1.6.1"
 bytemuck = { version = "1.14.1", features = [ "derive", "min_const_generics", "extern_crate_alloc" ] }
 serde = { version = "1", optional = true }
 serde_arrays = { version = "0.1", optional = true }
 
 [features]
-serde = [ "dep:serde", "serde_arrays", "serde/derive", "k256/serde", "x25519-dalek/serde" ]
+serde = [ "dep:serde", "serde_arrays", "serde/derive", "k256/serde" ]

--- a/crates/sl-oblivious/src/endemic_ot.rs
+++ b/crates/sl-oblivious/src/endemic_ot.rs
@@ -1,28 +1,34 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
+use elliptic_curve::bigint::{Encoding, U256};
+use elliptic_curve::ops::Reduce;
+use elliptic_curve::{Field, Group};
 use std::array;
 
 use merlin::Transcript;
 use rand::prelude::*;
-use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::{
     constants::ENDEMIC_OT_LABEL, params::consts::*, utils::ExtractBit,
 };
+use k256::{
+    elliptic_curve::group::GroupEncoding, ProjectivePoint, Scalar, Secp256k1,
+};
+use std::ops::Neg;
 
 /// EndemicOT Message 1
 #[derive(Clone, Copy, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
 #[repr(C)]
 pub struct EndemicOTMsg1 {
     // values r_0 and r_1 from OTReceiver to OTSender
-    r_list: [[[u8; 32]; 2]; LAMBDA_C],
+    r_list: [[[u8; 33]; 2]; LAMBDA_C],
 }
 
 impl Default for EndemicOTMsg1 {
     fn default() -> Self {
         Self {
-            r_list: [[[0u8; 32]; 2]; LAMBDA_C],
+            r_list: [[[0u8; 33]; 2]; LAMBDA_C],
         }
     }
 }
@@ -32,21 +38,22 @@ impl Default for EndemicOTMsg1 {
 #[repr(C)]
 pub struct EndemicOTMsg2 {
     // values m_b_0 and m_b_1 from OTSender to OTReceiver
-    m_b_list: [[[u8; 32]; 2]; LAMBDA_C],
+    m_b_list: [[[u8; 33]; 2]; LAMBDA_C],
 }
 
 impl Default for EndemicOTMsg2 {
     fn default() -> Self {
         Self {
-            m_b_list: [[[0u8; 32]; 2]; LAMBDA_C],
+            m_b_list: [[[0u8; 33]; 2]; LAMBDA_C],
         }
     }
 }
 
 /// The one time pad encryption keys for a single choice.
+#[derive(Debug)]
 pub(crate) struct OneTimePadEncryptionKeys {
-    pub(crate) rho_0: [u8; 32],
-    pub(crate) rho_1: [u8; 32],
+    pub(crate) rho_0: [u8; LAMBDA_C_BYTES],
+    pub(crate) rho_1: [u8; LAMBDA_C_BYTES],
 }
 
 /// The output of the OT sender.
@@ -57,21 +64,60 @@ pub struct SenderOutput {
 /// The output of the OT receiver.
 pub struct ReceiverOutput {
     pub(crate) choice_bits: [u8; LAMBDA_C_BYTES], // LAMBDA_C bits
-    pub(crate) otp_dec_keys: [[u8; 32]; LAMBDA_C],
+    pub(crate) otp_dec_keys: [[u8; LAMBDA_C_BYTES]; LAMBDA_C],
 }
 
-// RO for EndemicOT
-fn h_function(index: usize, session_id: &[u8], pk: &[u8; 32]) -> [u8; 32] {
+/// RO for EndemicOT
+fn h_function(
+    ro_index: usize,
+    batch_index: usize,
+    session_id: &[u8],
+    pk: &ProjectivePoint,
+) -> ProjectivePoint {
     let mut t = Transcript::new(&ENDEMIC_OT_LABEL);
 
     t.append_message(b"session-id", session_id);
-    t.append_message(b"index", &(index as u16).to_be_bytes());
-    t.append_message(b"pk", pk);
+    t.append_message(b"ro-index", &(ro_index as u16).to_be_bytes());
+    t.append_message(b"batch_index", &(batch_index as u16).to_be_bytes());
+    t.append_message(b"pk", &pk.to_affine().to_bytes());
 
     let mut output = [0u8; 32];
     t.challenge_bytes(b"", &mut output);
 
+    let s = elliptic_curve::Scalar::<Secp256k1>::reduce(U256::from_be_bytes(
+        output,
+    ));
+
+    ProjectivePoint::GENERATOR * s
+}
+
+/// create LAMBDA_C_BYTES ot seed
+fn h_function_2(
+    batch_index: usize,
+    pk: &ProjectivePoint,
+) -> [u8; LAMBDA_C_BYTES] {
+    let mut t = Transcript::new(&ENDEMIC_OT_LABEL);
+
+    t.append_message(b"batch_index", &(batch_index as u16).to_be_bytes());
+    t.append_message(b"pk", &pk.to_affine().to_bytes());
+
+    let mut output = [0u8; LAMBDA_C_BYTES];
+    t.challenge_bytes(b"ot-seed", &mut output);
+
     output
+}
+
+/// Encode ProjectivePoint
+fn encode_point(p: &ProjectivePoint) -> [u8; 33] {
+    p.to_affine().to_bytes()[..].try_into().unwrap()
+}
+
+/// Decode ProjectivePoint
+fn decode_point(bytes: &[u8; 33]) -> Option<ProjectivePoint> {
+    let mut repr = <ProjectivePoint as GroupEncoding>::Repr::default();
+    AsMut::<[u8]>::as_mut(&mut repr).copy_from_slice(bytes);
+
+    ProjectivePoint::from_bytes(&repr).into()
 }
 
 /// Sender of the Endemic OT protocol.
@@ -85,32 +131,50 @@ impl EndemicOTSender {
         msg1: &EndemicOTMsg1,
         msg2: &mut EndemicOTMsg2,
         rng: &mut R,
-    ) -> SenderOutput {
-        SenderOutput {
-            otp_enc_keys: array::from_fn(|idx| {
-                let [r_0, r_1] = &msg1.r_list[idx];
+    ) -> Result<SenderOutput, &'static str> {
+        let mut error = false;
+        let otp_enc_keys = array::from_fn(|idx| {
+            let [r_0, r_1] = &msg1.r_list[idx];
 
-                let h_r_0 = h_function(idx, session_id, r_0);
-                let h_r_1 = h_function(idx, session_id, r_1);
+            let r_0_point = match decode_point(r_0) {
+                None => {
+                    error = true;
+                    ProjectivePoint::IDENTITY
+                }
+                Some(v) => v,
+            };
+            let r_1_point = match decode_point(r_1) {
+                None => {
+                    error = true;
+                    ProjectivePoint::IDENTITY
+                }
+                Some(v) => v,
+            };
 
-                let m_a_0 = PublicKey::from(xor_byte_arrays(r_0, &h_r_1));
-                let m_a_1 = PublicKey::from(xor_byte_arrays(r_1, &h_r_0));
+            let m_a_0 =
+                r_0_point + h_function(0, idx, session_id, &r_1_point);
+            let m_a_1 =
+                r_1_point + h_function(1, idx, session_id, &r_0_point);
 
-                let t_b_0 = StaticSecret::random_from_rng(&mut *rng);
-                let t_b_1 = StaticSecret::random_from_rng(&mut *rng);
+            let t_b_0 = Scalar::random(&mut *rng);
+            let t_b_1 = Scalar::random(&mut *rng);
 
-                let m_b_0 = PublicKey::from(&t_b_0).to_bytes();
-                let m_b_1 = PublicKey::from(&t_b_1).to_bytes();
+            let m_b_0 = ProjectivePoint::GENERATOR * t_b_0;
+            let m_b_1 = ProjectivePoint::GENERATOR * t_b_1;
 
-                msg2.m_b_list[idx] = [m_b_0, m_b_1];
+            msg2.m_b_list[idx] = [encode_point(&m_b_0), encode_point(&m_b_1)];
 
-                // check key generation
-                let rho_0 = t_b_0.diffie_hellman(&m_a_0).to_bytes();
-                let rho_1 = t_b_1.diffie_hellman(&m_a_1).to_bytes();
+            let rho_0 = h_function_2(idx, &(m_a_0 * t_b_0));
+            let rho_1 = h_function_2(idx, &(m_a_1 * t_b_1));
 
-                OneTimePadEncryptionKeys { rho_0, rho_1 }
-            }),
+            OneTimePadEncryptionKeys { rho_0, rho_1 }
+        });
+
+        if error {
+            return Err("Decode error");
         }
+
+        Ok(SenderOutput { otp_enc_keys })
     }
 }
 
@@ -120,7 +184,7 @@ impl EndemicOTSender {
 pub struct EndemicOTReceiver {
     packed_choice_bits: [u8; LAMBDA_C_BYTES],
     #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
-    t_a_list: [StaticSecret; LAMBDA_C],
+    t_a_list: [Scalar; LAMBDA_C],
 }
 
 impl EndemicOTReceiver {
@@ -132,49 +196,66 @@ impl EndemicOTReceiver {
     ) -> Self {
         let next_state = Self {
             packed_choice_bits: rng.gen(),
-            t_a_list: array::from_fn(|_| {
-                StaticSecret::random_from_rng(&mut *rng)
-            }),
+            t_a_list: array::from_fn(|_| Scalar::random(&mut *rng)),
         };
 
         msg1.r_list
             .iter_mut()
             .enumerate()
             .for_each(|(idx, r_values)| {
-                let t_a = &next_state.t_a_list[idx];
-
-                let r_other = rng.gen();
-                let r_choice = xor_byte_arrays(
-                    &PublicKey::from(t_a).to_bytes(),
-                    &h_function(idx, session_id, &r_other),
-                );
-
                 let random_choice_bit =
                     next_state.packed_choice_bits.extract_bit(idx) as usize;
 
-                r_values[random_choice_bit] = r_choice;
-                r_values[random_choice_bit ^ 1] = r_other;
+                let t_a = &next_state.t_a_list[idx];
+
+                let r_other = ProjectivePoint::random(&mut *rng);
+                let r_choice = ProjectivePoint::GENERATOR * t_a
+                    + h_function(
+                        random_choice_bit,
+                        idx,
+                        session_id,
+                        &r_other,
+                    )
+                    .neg();
+
+                r_values[random_choice_bit] = encode_point(&r_choice);
+                r_values[random_choice_bit ^ 1] = encode_point(&r_other);
             });
 
         next_state
     }
 
-    pub fn process(self, msg2: &EndemicOTMsg2) -> ReceiverOutput {
-        let rho_w_vec: [[u8; 32]; LAMBDA_C] = std::array::from_fn(|idx| {
-            let m_b_values = &msg2.m_b_list[idx];
-            let random_choice_bit = self.packed_choice_bits.extract_bit(idx);
+    pub fn process(
+        self,
+        msg2: &EndemicOTMsg2,
+    ) -> Result<ReceiverOutput, &'static str> {
+        let mut error = false;
+        let rho_w_vec: [[u8; LAMBDA_C_BYTES]; LAMBDA_C] =
+            array::from_fn(|idx| {
+                let m_b_values = &msg2.m_b_list[idx];
+                let random_choice_bit =
+                    self.packed_choice_bits.extract_bit(idx);
 
-            let m_b_value = m_b_values[random_choice_bit as usize];
+                let m_b_value = m_b_values[random_choice_bit as usize];
+                let m_b_value = match decode_point(&m_b_value) {
+                    None => {
+                        error = true;
+                        ProjectivePoint::IDENTITY
+                    }
+                    Some(v) => v,
+                };
+                let res = m_b_value * self.t_a_list[idx];
+                h_function_2(idx, &res)
+            });
 
-            self.t_a_list[idx]
-                .diffie_hellman(&PublicKey::from(m_b_value))
-                .to_bytes()
-        });
+        if error {
+            return Err("Decode error");
+        }
 
-        ReceiverOutput {
+        Ok(ReceiverOutput {
             choice_bits: self.packed_choice_bits,
             otp_dec_keys: rho_w_vec,
-        }
+        })
     }
 }
 
@@ -183,18 +264,13 @@ impl ReceiverOutput {
     /// Create a new `ReceiverOutput`.
     pub fn new(
         choice_bits: [u8; LAMBDA_C_BYTES],
-        otp_dec_keys: [[u8; 32]; LAMBDA_C],
+        otp_dec_keys: [[u8; LAMBDA_C_BYTES]; LAMBDA_C],
     ) -> Self {
         Self {
             choice_bits,
             otp_dec_keys,
         }
     }
-}
-
-/// XOR two byte arrays.
-fn xor_byte_arrays<const T: usize>(a: &[u8; T], b: &[u8; T]) -> [u8; T] {
-    std::array::from_fn(|i| a[i] ^ b[i])
 }
 
 #[cfg(test)]
@@ -213,9 +289,10 @@ mod test {
 
         let mut msg2 = EndemicOTMsg2::default();
         let sender_output =
-            EndemicOTSender::process(&session_id, &msg1, &mut msg2, &mut rng);
+            EndemicOTSender::process(&session_id, &msg1, &mut msg2, &mut rng)
+                .unwrap();
 
-        let receiver_output = receiver.process(&msg2);
+        let receiver_output = receiver.process(&msg2).unwrap();
 
         for i in 0..LAMBDA_C {
             let sender_pad = &sender_output.otp_enc_keys[i];


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI/CD
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the "Predictable Choice Bit Leakage in Oblivious Transfer Protocol" vulnerability 
in the Endemic OT implementation.

### Vulnerability Summary:
The vulnerability stems from the unfortunate combination of two factors: 
a misinterpretation of the $\oplus$ operator as bitwise XOR (whereas MR19 uses it to imply curve addition), 
and the choice of abstraction for the elliptic curve underlying the protocol.

The curve used in the sl-crypto implementation was Curve25519, which is
of order 8q where q is a prime. The honest key generation algorithm works
over a specific subgroup of order q, meaning that a randomly chosen point on
the curve is likely to be in the co-domain of honest key generation only with
probability 1/8. Consequently, a passively corrupt sender in the OT protocol
can distinguish the receiver’s honest public key from the random public key with probability 7/8.
This leaks the receiver’s choice bit to the sender with the same probability.

### Applied Fix:
We changed the underlying elliptic curve for the OT from Curve25519 to
secp256k1, which does not have such subtleties with the cofactor; all points
on the elliptic curve are in the co-domain of key generation. Additionally, we
replaced bitwise XOR with subtraction in the curve group.


## Related Tickets
https://slira.atlassian.net/browse/SL-872

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

