### PR TITLE
fix: make polynomial types generic over curves 

### DIFF
--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -39,7 +39,13 @@ serde = { version = "1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "sync", "macros"] }
+bincode = { version = "1" }
 
 [features]
-serde = ["dep:serde", "elliptic-curve/arithmetic", "k256/serde"]
+serde = [
+  "dep:serde",
+  "serde/serde_derive",
+  "elliptic-curve/arithmetic",
+  "k256/serde",
+]
 simple-relay = ["dep:tokio"]

--- a/crates/sl-mpc-mate/src/math.rs
+++ b/crates/sl-mpc-mate/src/math.rs
@@ -160,6 +160,15 @@ where
     }
 }
 
+impl<G> AsRef<[G]> for GroupPolynomial<G>
+where
+    G: Group + GroupEncoding,
+{
+    fn as_ref(&self) -> &[G] {
+        &self.coeffs
+    }
+}
+
 impl<G> GroupPolynomial<G>
 where
     G: Group + GroupEncoding,
@@ -183,10 +192,13 @@ where
     /// Add another polynomial's coefficients element wise to this one inplace.
     /// If the other polynomial has more coefficients than this one, the extra
     /// coefficients are ignored.
-    pub fn add_mut(&mut self, other: &Self) {
+    pub fn add_mut<T>(&mut self, other: T)
+    where
+        T: AsRef<[G]>,
+    {
         self.coeffs
             .iter_mut()
-            .zip(&other.coeffs)
+            .zip(other.as_ref())
             .for_each(|(a, b)| {
                 *a += b;
             });

--- a/crates/sl-mpc-mate/src/math.rs
+++ b/crates/sl-mpc-mate/src/math.rs
@@ -109,6 +109,21 @@ where
             })
             .sum()
     }
+
+    /// Evaluate the polynomial at the given point.
+    /// Arithmetic is done modulo the curve order
+    /// # Arguments
+    /// `x`: point at which to evaluate the polynomial.
+    pub fn evaluate_at(&self, x: &G::Scalar) -> G::Scalar {
+        self.coeffs
+            .iter()
+            .enumerate()
+            .map(|(i, coeff)| {
+                let result = x.pow_vartime([i as u64]);
+                result * coeff
+            })
+            .sum()
+    }
 }
 
 /// A polynomial with coefficients of type `ProjectivePoint`.

--- a/crates/sl-mpc-mate/src/math.rs
+++ b/crates/sl-mpc-mate/src/math.rs
@@ -243,18 +243,18 @@ pub fn feldman_verify<C: CurveArithmetic>(
 /// `n_i` (order of derivative)
 /// `n` (degree of polynomial - 1)
 /// `p` prime order of field
-pub fn polynomial_coeff_multipliers<G: CurveArithmetic>(
-    x_i: &NonZeroScalar<G>,
+pub fn polynomial_coeff_multipliers<C: CurveArithmetic>(
+    x_i: &NonZeroScalar<C>,
     n_i: usize,
     n: usize,
-) -> Vec<G::Scalar>
+) -> Vec<C::Scalar>
 where
-    G: CurveArithmetic<Uint = U256>,
+    C: CurveArithmetic<Uint = U256>,
 {
-    let mut v = vec![G::Scalar::ZERO; n];
+    let mut v = vec![C::Scalar::ZERO; n];
 
     v.iter_mut().enumerate().skip(n_i).for_each(|(idx, vi)| {
-        let num = G::Scalar::reduce(factorial_range(idx - n_i, idx));
+        let num = C::Scalar::reduce(factorial_range(idx - n_i, idx));
         let exponent = [(idx - n_i) as u64];
         let result = x_i.pow_vartime(exponent);
         *vi = num * result;
@@ -264,20 +264,20 @@ where
 }
 
 /// Get the birkhoff coefficients
-pub fn birkhoff_coeffs<G>(
-    params: &[(NonZeroScalar<G>, usize)],
-) -> Vec<G::Scalar>
+pub fn birkhoff_coeffs<C>(
+    params: &[(NonZeroScalar<C>, usize)],
+) -> Vec<C::Scalar>
 where
-    G: CurveArithmetic<Uint = U256>,
+    C: CurveArithmetic<Uint = U256>,
 {
     let n = params.len();
 
-    let matrix: Vec<Vec<G::Scalar>> = params
+    let matrix: Vec<Vec<C::Scalar>> = params
         .iter()
         .map(|(x_i, n_i)| polynomial_coeff_multipliers(x_i, *n_i, n))
         .collect();
 
-    let mut matrix_inv = matrix_inverse::<G>(matrix, n);
+    let mut matrix_inv = matrix_inverse::<C>(matrix, n);
 
     matrix_inv.swap_remove(0)
 }


### PR DESCRIPTION
We previously had generic curve support using the CurveArithmetic, but `curve25519-dalek` does not implement the traits. It implements the `Group` trait. Which is sufficient for our use case. This is also a tighter trait bound. 

Changes:
- Use `Group` instead of `CurveArithmetic`
- Fixes for the serde serialization 
- Added test for serde serialization. 