### PR TITLE
Add CI checks and migrate sl-paillier to crypto-bigint 0.6

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,0 @@
-[advisories]
-ignore = [
-       # rsa 0.9.9, used by sl-verifiable-enc
-       "RUSTSEC-2023-0071"
-]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --locked --package xtask --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+
+  pull_request:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.88 --profile minimal --component rustfmt
+      - name: Use Rust 1.88
+        run: rustup default 1.88
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.88 --profile minimal
+      - name: Use Rust 1.88
+        run: rustup default 1.88
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: Run cargo deny
+        run: cargo deny --locked --all-features check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.88 --profile minimal --component clippy
+      - name: Use Rust 1.88
+        run: rustup default 1.88
+      - name: Run clippy for every crate and feature combination
+        run: cargo run --locked --package xtask -- feature-matrix clippy -- --locked
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.88 --profile minimal
+      - name: Use Rust 1.88
+        run: rustup default 1.88
+      - name: Run tests for every crate and feature combination
+        run: cargo run --locked --package xtask -- feature-matrix test -- --locked --release

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-.cargo/config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -352,11 +352,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-primes"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a4eeb0a8686cfc94242c8860628627206a2b24148d6ab8f5d41c708438582f"
+checksum = "2acbaf157961745008b5a80ee1cc974150691304fe9177edf69747142bfd9878"
 dependencies = [
- "crypto-bigint 0.5.5",
+ "crypto-bigint 0.6.1",
  "rand_core",
 ]
 
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "sl-messages"
-version = "1.2.0-pre.3"
+version = "1.2.1"
 dependencies = [
  "aead",
  "bytemuck",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "sl-paillier"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -1630,6 +1630,13 @@ dependencies = [
  "rand_core",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,8 +1197,8 @@ name = "sl-mpc-mate"
 version = "1.1.0"
 dependencies = [
  "base64",
- "bincode",
  "bs58",
+ "ciborium",
  "derivation-path",
  "elliptic-curve",
  "hex",
@@ -1243,7 +1243,7 @@ dependencies = [
 name = "sl-paillier"
 version = "1.2.0"
 dependencies = [
- "bincode",
+ "ciborium",
  "criterion",
  "crypto-bigint 0.6.1",
  "crypto-primes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "xtask",
     "crates/sl-mpc-mate",
     "crates/sl-oblivious",
     "crates/sl-paillier",
@@ -25,7 +26,7 @@ chacha20 = { version = "0.9" }
 chacha20poly1305 = { version = "0.10.1" }
 criterion = "0.5"
 crypto-bigint = { version = "0.6.1", default-features = false }
-crypto-primes = { version = "0.5", default-features = false }
+crypto-primes = { version = "0.6", default-features = false }
 curve25519-dalek = { version = "4.1.3", default-features = false }
 derivation-path = "0.2.0"
 digest = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bincode = "1"
 bs58 = "0.5.0"
 bytemuck = { version = "1.22" }
 bytes = "1"
+ciborium = "0.2.2"
 chacha20 = { version = "0.9" }
 chacha20poly1305 = { version = "0.10.1" }
 criterion = "0.5"

--- a/README.md
+++ b/README.md
@@ -1,44 +1,75 @@
 # sl-crypto
 
-This repo contains libraries:
+`sl-crypto` is a Rust workspace with cryptographic and MPC-related crates used
+by Silence Laboratories.
 
-## sl-paillier
+## Workspace crates
 
-Implemention of Paillier encryption using fixed with big numbers
-from crypto-binint crate. This implemenation is slower that kzen-paillier
-but it is pure Rust and use constant-time computations.
+- `sl-compute-common`: utilities for secure compute
+- `sl-messages`: message exchange and relay components for MPC protocols
+- `sl-mpc-mate`: utilities for secure multi-party computation
+- `sl-mpc-traits`: small utility traits shared across crates
+- `sl-oblivious`: oblivious transfer protocols
+- `sl-paillier`: Paillier encryption built on `crypto-bigint`
+- `sl-shamir`: Shamir secret sharing
+- `sl-verifiable-enc`: verifiable encryption
 
-Also it is GPL/LGPL free.
+Additional crate-specific documentation is available in:
 
-## sl-mpc-mate
+- [`crates/sl-messages/README.md`](crates/sl-messages/README.md)
+- [`crates/sl-verifiable-enc/README.md`](crates/sl-verifiable-enc/README.md)
 
-Implementation of new "messaging scheme". Implements message relay or
-async coordinator.
+## Toolchain
 
-Key modules and types:
+The workspace currently targets Rust `1.88`.
 
-```rust
-message::MsgId
-message::Builder::<Signed>::encode(id, ttl, key, payload)
-message::builder::<Encrypted>::encode(id, ttl, key, payload)
+## Development
 
-message::Message::from_buffer(&mut buffer)
-message::Message::verify_and_decode()
-message::Message::decrypt_and_decode()
+This repository includes a workspace-local Cargo alias:
 
-coord::Relay
-coord::SimpleMessageRelay
+```bash
+cargo xtask ...
 ```
 
-## sl-oblivious
+The alias expands to:
 
-Base code for DKLs23
+```bash
+cargo run --locked --package xtask -- ...
+```
 
-## sl-verifiable-enc
+The main helper currently implemented in `xtask` is `feature-matrix`. It runs
+`cargo clippy` or `cargo test` for every workspace crate and every explicit
+feature combination of that crate.
 
-Verifiable encryption library
+Examples:
 
-Refer to it's [readme](/crates/sl-verifiable-enc/README.md) for usage
+```bash
+# Show the test matrix without executing it
+cargo xtask feature-matrix test --dry-run
 
+# Run clippy for every crate / feature combination
+cargo xtask feature-matrix clippy -- --locked
 
+# Run tests only for sl-messages across its feature combinations
+cargo xtask feature-matrix test --package sl-messages -- --locked --release
 
+# Inspect the generated commands for one crate
+cargo xtask feature-matrix test --package sl-paillier --dry-run
+```
+
+Arguments after `--` are forwarded to the underlying Cargo command. For
+example, `--release` and `--locked` are passed through to every generated
+`cargo test` invocation.
+
+## CI
+
+GitHub Actions runs the following checks on pushes and pull requests to `main`:
+
+```bash
+cargo fmt --all --check
+cargo deny --locked --all-features check
+cargo run --locked --package xtask -- feature-matrix clippy -- --locked
+cargo run --locked --package xtask -- feature-matrix test -- --locked --release
+```
+
+Running those commands locally is the closest way to reproduce CI.

--- a/crates/sl-compute-common/src/lib.rs
+++ b/crates/sl-compute-common/src/lib.rs
@@ -53,7 +53,7 @@ impl BinaryArithmetic {
 
         if len != FIELD_SIZE_BYTES {
             let zero_pad = FIELD_SIZE_BYTES - len;
-            value.extend(std::iter::repeat(0u8).take(zero_pad));
+            value.extend(std::iter::repeat_n(0u8, zero_pad));
         }
         BinaryArithmetic {
             value: value.try_into().unwrap(),
@@ -297,7 +297,7 @@ impl BinaryString {
     }
 
     pub fn new_with_zeros(size_in_bits: usize) -> Self {
-        let size_in_bytes = (size_in_bits + 7) / 8;
+        let size_in_bytes = size_in_bits.div_ceil(8);
         BinaryString {
             length: size_in_bits as u64,
             value: vec![0u8; size_in_bytes],
@@ -317,7 +317,7 @@ impl BinaryString {
     }
 
     pub fn with_capacity(size: usize) -> Self {
-        let num_bytes = (size + 7) / 8;
+        let num_bytes = size.div_ceil(8);
         BinaryString {
             length: 0_u64,
             value: Vec::with_capacity(num_bytes),
@@ -444,7 +444,7 @@ impl BinaryString {
     /// Use only for unverified_list
     pub fn append_bytes_with_padding(&mut self, other: &[u8]) {
         // pad length
-        self.length = (self.length + 7) / 8 * 8;
+        self.length = self.length.div_ceil(8) * 8;
         self.length += other.len() as u64;
         self.value.extend_from_slice(other);
     }
@@ -517,7 +517,7 @@ impl BinaryStringShare {
     }
 
     pub fn zero(length: usize) -> Self {
-        let num_bytes = (length + 7) / 8;
+        let num_bytes = length.div_ceil(8);
         BinaryStringShare {
             length: length as u64,
             value1: vec![0u8; num_bytes],
@@ -568,7 +568,7 @@ impl BinaryStringShare {
     }
 
     pub fn with_capacity(size: usize) -> Self {
-        let num_bytes = (size + 7) / 8;
+        let num_bytes = size.div_ceil(8);
         BinaryStringShare {
             length: 0_u64,
             value1: Vec::with_capacity(num_bytes),
@@ -827,7 +827,7 @@ impl BinaryStringShare {
     /// Use only for verify mult triples
     pub fn append_with_padding(&mut self, other: &Self) {
         // pad length
-        self.length = (self.length + 7) / 8 * 8;
+        self.length = self.length.div_ceil(8) * 8;
         self.length += (other.value1.len() * 8) as u64;
         self.value1.extend_from_slice(&other.value1);
         self.value2.extend_from_slice(&other.value2);
@@ -839,7 +839,7 @@ impl BinaryStringShare {
         other: &BinaryArithmeticShare,
     ) {
         // pad length
-        self.length = (self.length + 7) / 8 * 8;
+        self.length = self.length.div_ceil(8) * 8;
         self.length += (other.value1.len() * 8) as u64;
         self.value1.extend_from_slice(&other.value1);
         self.value2.extend_from_slice(&other.value2);
@@ -907,7 +907,7 @@ impl CommonRandomness {
         &mut self,
         l: usize,
     ) -> BinaryStringShare {
-        let size_in_bytes = (l + 7) / 8;
+        let size_in_bytes = l.div_ceil(8);
         let mut value1 = Vec::with_capacity(size_in_bytes);
         let mut value2 = Vec::with_capacity(size_in_bytes);
         for _ in 0..size_in_bytes {

--- a/crates/sl-messages/CHANGELOG.md
+++ b/crates/sl-messages/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `sl-messages` are documented in this file.
 
+## [1.2.1] - 2026-03-10
+
+### Fixed
+
+- Stabilized the `relay::mux::test::mux` test by ignoring echoed header-only
+  `ASK` frames before asserting on the relayed payload message.
+- Added the missing dependencies required to build with the `mux` feature.
+
 ## [1.2.0] - 2026-03-10
 
 ### Changed

--- a/crates/sl-messages/Cargo.toml
+++ b/crates/sl-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sl-messages"
-version = "1.2.0"
+version = "1.2.1"
 license-file = "../../LICENSE"
 edition = "2021"
 rust-version = "1.88"
@@ -29,7 +29,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "tim
 
 [features]
 default = []
-mux = [ "tokio/sync", "tokio/rt" ]
+mux = [ "tokio/macros", "tokio/sync", "tokio/rt" ]
 fast-ws = [ "fastwebsockets", "tokio/macros", "tokio/sync", "tokio/rt" ]
 setup = ["dep:derivation-path"]
 simple-relay = []

--- a/crates/sl-messages/src/message.rs
+++ b/crates/sl-messages/src/message.rs
@@ -76,7 +76,7 @@ impl fmt::Debug for MsgId {
 impl fmt::UpperHex for MsgId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in &self.0 {
-            write!(f, "{:02X}", b)?;
+            write!(f, "{b:02X}")?;
         }
         Ok(())
     }
@@ -85,7 +85,7 @@ impl fmt::UpperHex for MsgId {
 impl fmt::LowerHex for MsgId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in &self.0 {
-            write!(f, "{:02x}", b)?;
+            write!(f, "{b:02x}")?;
         }
         Ok(())
     }
@@ -245,7 +245,7 @@ impl MsgHdr {
         let ttl = match ttl {
             0..256 => ttl as u16,
             256..Self::MAX_TTL => {
-                let ttl = (ttl + 9) / 10 - 26;
+                let ttl = ttl.div_ceil(10) - 26;
                 let ttl = ttl + 256;
 
                 ttl as u16

--- a/crates/sl-messages/src/proto/encrypted.rs
+++ b/crates/sl-messages/src/proto/encrypted.rs
@@ -106,7 +106,7 @@ pub trait EncryptedMessage: EncryptionScheme {
     }
 }
 
-///
+/// Key material used to encrypt and decrypt framed messages.
 pub trait MessageKey: Sized {
     /// Size of message footer.
     fn message_footer(&self) -> usize;

--- a/crates/sl-messages/src/relay/buffered.rs
+++ b/crates/sl-messages/src/relay/buffered.rs
@@ -325,7 +325,7 @@ impl<R: Relay> BufferedMsgRelay<R> {
                 return Ok(true);
             };
 
-            handler(&val, trailer, party_id)?;
+            handler(val, trailer, party_id)?;
 
             Ok::<_, E>(false)
         })

--- a/crates/sl-messages/src/relay/mux.rs
+++ b/crates/sl-messages/src/relay/mux.rs
@@ -208,7 +208,10 @@ mod test {
     use std::time::Duration;
 
     use crate::{
-        message::{allocate_message, InstanceId, MessageTag, MsgId},
+        message::{
+            allocate_message, InstanceId, MessageTag, MsgId,
+            MESSAGE_HEADER_SIZE,
+        },
         relay::SimpleMessageRelay,
     };
 
@@ -216,6 +219,15 @@ mod test {
 
     fn mk_msg(id: &MsgId) -> Bytes {
         allocate_message(id, Duration::from_secs(10), 0, &[0, 255])
+    }
+
+    async fn next_message<R: Relay>(relay: &mut R) -> BytesMut {
+        loop {
+            let msg = relay.next().await.expect("relay closed unexpectedly");
+            if msg.len() > MESSAGE_HEADER_SIZE {
+                return msg;
+            }
+        }
     }
 
     //
@@ -253,7 +265,7 @@ mod test {
         // c2 -> s -> c1 -> m1
         c2.send(msg_0.clone()).await.unwrap();
 
-        let msg_0_in = m1.next().await.unwrap();
+        let msg_0_in = next_message(&mut m1).await;
 
         assert_eq!(msg_0, msg_0_in);
 

--- a/crates/sl-messages/src/relay/mux.rs
+++ b/crates/sl-messages/src/relay/mux.rs
@@ -136,13 +136,11 @@ impl MsgRelayMux {
                     // broadcast ASK message to all internal
                     // connections.
                     let _ = input_asks.send(msg.into());
-                } else {
-                    if let Some(q) = <&MsgId>::try_from(msg.as_ref())
-                        .ok()
-                        .and_then(|id| asks.lock().unwrap().remove(id))
-                    {
-                        q.push(msg);
-                    }
+                } else if let Some(q) = <&MsgId>::try_from(msg.as_ref())
+                    .ok()
+                    .and_then(|id| asks.lock().unwrap().remove(id))
+                {
+                    q.push(msg);
                 }
             }
         });

--- a/crates/sl-messages/src/relay/simple.rs
+++ b/crates/sl-messages/src/relay/simple.rs
@@ -167,6 +167,12 @@ pub struct MsgRelay<Q> {
     inner: Arc<Mutex<Inner<Q>>>,
 }
 
+impl<Q: InputQueue> Default for MsgRelay<Q> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<Q: InputQueue> MsgRelay<Q> {
     pub fn new() -> Self {
         Self {

--- a/crates/sl-messages/src/setup/keygen.rs
+++ b/crates/sl-messages/src/setup/keygen.rs
@@ -18,9 +18,7 @@ const DEFAULT_TTL: u64 = 100; // smaller timeout might fail tests
 
 use crate::setup::{
     keys::{NoSignature, NoSigningKey, NoVerifyingKey},
-    KeygenSetupMessage,
-    ProtocolParticipant,
-    WeightedKeygenSetupMessage,
+    KeygenSetupMessage, ProtocolParticipant, WeightedKeygenSetupMessage,
 };
 
 /// Concrete setup context for key-generation rounds.

--- a/crates/sl-messages/src/setup/quorum_change.rs
+++ b/crates/sl-messages/src/setup/quorum_change.rs
@@ -9,8 +9,7 @@ use crate::{
     message::InstanceId,
     setup::{
         keys::{NoSignature, NoSigningKey, NoVerifyingKey},
-        ProtocolParticipant,
-        QuorumChangeSetupMessage,
+        ProtocolParticipant, QuorumChangeSetupMessage,
         WeightedQuorumChangeSetupMessage,
     },
 };

--- a/crates/sl-mpc-mate/Cargo.toml
+++ b/crates/sl-mpc-mate/Cargo.toml
@@ -27,7 +27,7 @@ rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-bincode = { version = "1" }
+ciborium = { workspace = true }
 
 [features]
 serde = [

--- a/crates/sl-mpc-mate/src/bip32.rs
+++ b/crates/sl-mpc-mate/src/bip32.rs
@@ -18,6 +18,11 @@ use thiserror::Error;
 
 /// 4-byte Key fingerprint
 pub type KeyFingerPrint = [u8; 4];
+pub type ChildPubkeyDerivation<C> = (
+    <C as CurveArithmetic>::Scalar,
+    <C as CurveArithmetic>::ProjectivePoint,
+    [u8; 32],
+);
 
 const KEY_SIZE: usize = 32;
 
@@ -147,7 +152,7 @@ pub fn derive_child_pubkey<C>(
     parent_pubkey: &C::ProjectivePoint,
     parent_chain_code: [u8; 32],
     child_number: &ChildIndex,
-) -> Result<(C::Scalar, C::ProjectivePoint, [u8; 32]), BIP32Error>
+) -> Result<ChildPubkeyDerivation<C>, BIP32Error>
 where
     C: CurveArithmetic<FieldBytesSize = U32>,
     C::FieldBytesSize: ModulusSize,

--- a/crates/sl-mpc-mate/src/math.rs
+++ b/crates/sl-mpc-mate/src/math.rs
@@ -464,16 +464,18 @@ mod tests {
 
         let mut rng = rand::thread_rng();
         let poly1 = Polynomial::<ProjectivePoint>::random(&mut rng, 5);
-        let bytes = bincode::serialize(&poly1).unwrap();
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&poly1, &mut bytes).unwrap();
         let poly2: Polynomial<ProjectivePoint> =
-            bincode::deserialize(&bytes).unwrap();
+            ciborium::from_reader(bytes.as_slice()).unwrap();
 
         let g_poly1 = poly1.commit();
 
-        let bytes = bincode::serialize(&g_poly1).unwrap();
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&g_poly1, &mut bytes).unwrap();
 
         let g_poly2: GroupPolynomial<ProjectivePoint> =
-            bincode::deserialize(&bytes).unwrap();
+            ciborium::from_reader(bytes.as_slice()).unwrap();
 
         assert_eq!(poly1, poly2);
         assert_eq!(g_poly1, g_poly2);

--- a/crates/sl-oblivious/src/rvole_ot_variant.rs
+++ b/crates/sl-oblivious/src/rvole_ot_variant.rs
@@ -95,7 +95,6 @@ impl Default for RVOLEMsg2 {
     }
 }
 
-///
 #[derive(Clone, Copy, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
 #[repr(C)]
 pub struct RVOLEReceiver {
@@ -103,7 +102,6 @@ pub struct RVOLEReceiver {
     beta: [u8; XI_BYTES],
 }
 
-///
 impl RVOLEReceiver {
     /// Create a new RVOLE receiver
     pub fn new<R: CryptoRngCore>(
@@ -169,7 +167,6 @@ impl RVOLEReceiver {
 }
 
 impl RVOLEReceiver {
-    ///
     pub fn process(
         &self,
         rvole_output_2: &RVOLEMsg2,
@@ -315,11 +312,9 @@ impl RVOLEReceiver {
     }
 }
 
-///
 pub struct RVOLESender;
 
 impl RVOLESender {
-    ///
     pub fn process<R: CryptoRngCore>(
         session_id: &[u8],
         a: &[Scalar; L_BATCH],

--- a/crates/sl-paillier/CHANGELOG.md
+++ b/crates/sl-paillier/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to `sl-paillier` are documented in this file.
+
+## [1.2.0] - 2026-03-10
+
+### Changed
+
+- Upgraded the crate to `crypto-bigint 0.6` and `crypto-primes 0.6`.
+- Migrated modular arithmetic internals from dynamic residues to Montgomery
+  forms and parameters.
+- Enabled the `alloc` feature on `crypto-bigint` to support generic modular
+  inverse handling during key setup.
+
+### Fixed
+
+- Restored compatibility of encryption, decryption, CRT recombination, and
+  `extract_n_root` helpers with the current `crypto-bigint` APIs.
+- Removed secret-side uses of `_vartime` modular reduction and parameter
+  construction in private-key paths.
+- Updated Criterion benchmarks and public traits to match the new bigint and
+  modular arithmetic APIs.
+
+## [1.1.0] - 2026-01-13
+
+### Added
+
+- Initial published release of `sl-paillier` as a standalone Paillier
+  encryption crate.

--- a/crates/sl-paillier/Cargo.toml
+++ b/crates/sl-paillier/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "sl-paillier"
 license-file = "../../LICENSE"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.88"
 repository = "https://github.com/silence-laboratories/sl-crypto"
 description = "Paillier encryption"
 
 [dependencies]
-crypto-bigint = { workspace = true, features = ["rand_core"] }
+crypto-bigint = { workspace = true, features = ["alloc", "rand_core"] }
 crypto-primes = { workspace = true }
 rand_core = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/sl-paillier/Cargo.toml
+++ b/crates/sl-paillier/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 
 
 [dev-dependencies]
-bincode = { workspace = true }
+ciborium = { workspace = true }
 criterion = { workspace = true }
 lazy_static = { workspace = true }
 quickcheck = { workspace = true }

--- a/crates/sl-paillier/README.md
+++ b/crates/sl-paillier/README.md
@@ -1,1 +1,62 @@
-# NOT MAINTAINED - breaking changes with crypto-bigint 0.6.1
+# sl-paillier
+
+`sl-paillier` provides a Paillier cryptosystem implementation built on
+[`crypto-bigint`](https://docs.rs/crypto-bigint).
+
+The crate currently targets Rust `1.88` and ships a 2048-bit configuration as
+its main public API.
+
+## Main types
+
+- `SK2048`: secret key
+- `PK2048`: public key
+- `RawPlaintext`
+- `RawCiphertext`
+
+## Features
+
+- `serde`: enables serialization support for the 2048-bit key and ciphertext
+  types, and exposes `MinimalSK2048` / `MinimalPK2048` for compact key
+  serialization
+
+## Supported operations
+
+- key generation with `SK2048::gen()` / `SK2048::gen_keys()`
+- plaintext construction with `PK2048::message()` and `PK2048::into_message()`
+- encryption with `PK2048::encrypt()` or `PK2048::encrypt_with_r()`
+- decryption with `SK2048::decrypt()` and CRT-accelerated `SK2048::decrypt_fast()`
+- additive homomorphism with `PK2048::add()`
+- multiplication by a plaintext scalar with `PK2048::mul()`
+
+`PK2048::mul_vartime()` is also exposed as an explicitly variable-time variant.
+
+## Example
+
+```rust
+use rand::thread_rng;
+use sl_paillier::SK2048;
+
+let mut rng = thread_rng();
+let (sk, pk) = SK2048::gen_keys(&mut rng);
+
+let m1 = pk.message(&[5]).unwrap();
+let m2 = pk.message(&[9]).unwrap();
+
+let c1 = pk.encrypt(&m1, &mut rng);
+let c2 = pk.encrypt(&m2, &mut rng);
+
+let sum = pk.add(&c1, &c2);
+let doubled = pk.mul(&c1, &pk.message(&[2]).unwrap());
+
+assert_eq!(sk.decrypt(&sum), pk.message(&[14]).unwrap());
+assert_eq!(sk.decrypt_fast(&sum), pk.message(&[14]).unwrap());
+assert_eq!(sk.decrypt_fast(&doubled), pk.message(&[10]).unwrap());
+```
+
+## Notes
+
+- `PK2048::message()` interprets input bytes in little-endian order and returns
+  `None` if the resulting integer is not smaller than `n`.
+- `decrypt_fast()` uses CRT precomputation and is intended to produce the same
+  result as `decrypt()`.
+- Benchmarks live in [`benches/sl-paillier.rs`](benches/sl-paillier.rs).

--- a/crates/sl-paillier/benches/sl-paillier.rs
+++ b/crates/sl-paillier/benches/sl-paillier.rs
@@ -41,7 +41,7 @@ fn sl_pk() -> (U2048, PK) {
     let r: U2048 = from_hex(R);
     let p: U1024 = from_hex(P);
     let q: U1024 = from_hex(Q);
-    let n = p.mul_wide(&q).into();
+    let n = p.split_mul(&q).into();
 
     let pk = PK::from_n(&n);
 

--- a/crates/sl-paillier/src/lib.rs
+++ b/crates/sl-paillier/src/lib.rs
@@ -211,8 +211,10 @@ pub trait IntoRawPlaintext<const L: usize, T> {
     fn into_plaintext(self, msg: T) -> Option<RawPlaintext<L>>;
 }
 
-fn inv_mod_uint<const L: usize>(value: &Uint<L>, modulus: &Uint<L>) -> Uint<L>
-{
+fn inv_mod_uint<const L: usize>(
+    value: &Uint<L>,
+    modulus: &Uint<L>,
+) -> Uint<L> {
     let value = BoxedUint::from(value);
     let modulus = BoxedUint::from(modulus);
     let inverse = value
@@ -378,10 +380,7 @@ where
         // L_p(cp^{p-1} mod p^2) h_p mod p
         let p_wide_nz = NonZero::new(p.resize::<M>()).unwrap();
         let mp: Uint<P> = MontyForm::new(&cp, *param)
-            .pow_bounded_exp(
-                &p.wrapping_sub(&Uint::ONE),
-                Uint::<P>::BITS,
-            )
+            .pow_bounded_exp(&p.wrapping_sub(&Uint::ONE), Uint::<P>::BITS)
             .retrieve()
             .wrapping_sub(&Uint::ONE) // Lp(x) = (x-1)/p
             .wrapping_div(&p_wide_nz)
@@ -409,12 +408,7 @@ where
     pub fn extract_n_root(
         &self,
         z: &Uint<M>,
-        init_params: &(
-            Uint<P>,
-            Uint<P>,
-            MontyParams<P>,
-            MontyParams<P>,
-        ),
+        init_params: &(Uint<P>, Uint<P>, MontyParams<P>, MontyParams<P>),
     ) -> Uint<M> {
         let (zp, zq) = decompose(z, &self.p, &self.q);
         let rp = MontyForm::new(&zp, init_params.2)
@@ -609,7 +603,8 @@ where
         let r = MontyForm::new(&r.resize::<C>(), self.params);
 
         // r^N mod N^2
-        let r_pow_n = r.pow_bounded_exp(self.n.as_ref(), self.n.as_ref().bits_vartime());
+        let r_pow_n = r
+            .pow_bounded_exp(self.n.as_ref(), self.n.as_ref().bits_vartime());
 
         //
         // g == (1 + N)
@@ -621,7 +616,8 @@ where
         // 1 + m*N <= 1 + N^2 - N < N^2
         //
         let g_pow_m = MontyForm::new(
-            &Uint::<C>::from(m.0.split_mul(self.n.as_ref())).wrapping_add(&Uint::ONE),
+            &Uint::<C>::from(m.0.split_mul(self.n.as_ref()))
+                .wrapping_add(&Uint::ONE),
             self.params,
         );
 

--- a/crates/sl-paillier/src/lib.rs
+++ b/crates/sl-paillier/src/lib.rs
@@ -3,13 +3,18 @@
 
 use std::ops::Deref;
 
-use crypto_bigint::modular::runtime_mod::{DynResidue, DynResidueParams};
-use crypto_bigint::{Bounded, Encoding, NonZero, RandomMod, Split, Uint};
+use crypto_bigint::modular::{MontyForm, MontyParams};
+use crypto_bigint::{
+    BoxedUint, Concat, Encoding, NonZero, RandomMod, Split, Uint,
+};
 use crypto_bigint::{U1024, U2048, U4096};
 
 use crypto_primes::generate_prime_with_rng;
 
 use rand_core::CryptoRngCore;
+
+#[cfg(feature = "serde")]
+use crypto_bigint::Bounded;
 
 // print-type-size type: `SK<64, 32, 16>`: 5400 bytes, alignment: 8 bytes
 // print-type-size     field `.phi`: 256 bytes
@@ -24,12 +29,16 @@ use rand_core::CryptoRngCore;
 
 pub type SK2048 = SK<{ U4096::LIMBS }, { U2048::LIMBS }, { U1024::LIMBS }>;
 pub type PK2048 = PK<{ U4096::LIMBS }, { U2048::LIMBS }>;
+
+#[cfg(feature = "serde")]
 pub type MinimalSK2048 = MinimalSK<{ U1024::LIMBS }>;
+#[cfg(feature = "serde")]
 pub type MinimalPK2048 = MinimalPK<{ U4096::LIMBS }, { U2048::LIMBS }>;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "serde")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MinimalSK<const P: usize>
@@ -40,6 +49,7 @@ where
     pub q: Uint<P>,
 }
 
+#[cfg(feature = "serde")]
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MinimalPK<const NN: usize, const N: usize>
@@ -49,6 +59,7 @@ where
     pub n: NonZero<Uint<N>>,
 }
 
+#[cfg(feature = "serde")]
 impl<const NN: usize, const N: usize> MinimalPK<NN, N>
 where
     Uint<N>: Bounded + Encoding,
@@ -59,6 +70,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<const NN: usize, const N: usize> From<MinimalPK<NN, N>> for PK<NN, N>
 where
     Uint<N>: Bounded + Encoding,
@@ -69,7 +81,7 @@ where
         let nn: Uint<NN> = value.n.square_wide().into();
         PK {
             n: value.n,
-            params: DynResidueParams::new(&nn),
+            params: MontyParams::<NN>::new_vartime(nn.to_odd().unwrap()),
         }
     }
 }
@@ -199,10 +211,26 @@ pub trait IntoRawPlaintext<const L: usize, T> {
     fn into_plaintext(self, msg: T) -> Option<RawPlaintext<L>>;
 }
 
+fn inv_mod_uint<const L: usize>(value: &Uint<L>, modulus: &Uint<L>) -> Uint<L>
+{
+    let value = BoxedUint::from(value);
+    let modulus = BoxedUint::from(modulus);
+    let inverse = value
+        .inv_mod(&modulus)
+        .expect("value should be invertible for the provided modulus");
+    Uint::<L>::from_words(
+        inverse
+            .to_words()
+            .as_ref()
+            .try_into()
+            .expect("boxed inverse should preserve limb width"),
+    )
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct PK<const C: usize, const M: usize> {
     n: NonZero<Uint<M>>,
-    params: DynResidueParams<C>, // mod N^2
+    params: MontyParams<C>, // mod N^2
 }
 
 #[derive(Debug, Clone)]
@@ -215,20 +243,22 @@ pub struct SK<const C: usize, const M: usize, const P: usize> {
     q: Uint<P>,
     hq: Uint<P>,
     pinv_q: Uint<P>,
-    pp_params: DynResidueParams<M>,
-    qq_params: DynResidueParams<M>,
+    pp_params: MontyParams<M>,
+    qq_params: MontyParams<M>,
 }
 
 impl<const C: usize, const M: usize, const P: usize> SK<C, M, P>
 where
     Uint<C>: Split<Output = Uint<M>>,
     Uint<C>: From<(Uint<M>, Uint<M>)>,
+    Uint<M>: Concat<Output = Uint<C>>,
     Uint<M>: From<(Uint<P>, Uint<P>)>,
+    Uint<P>: Concat<Output = Uint<M>>,
     Uint<M>: Encoding + Split<Output = Uint<P>>,
 {
     pub fn gen_pq(rng: &mut impl CryptoRngCore) -> (Uint<P>, Uint<P>) {
-        let q = generate_prime_with_rng(rng, None);
-        let p = generate_prime_with_rng(rng, None);
+        let q = generate_prime_with_rng(rng, Uint::<P>::BITS);
+        let p = generate_prime_with_rng(rng, Uint::<P>::BITS);
 
         (p, q)
     }
@@ -250,27 +280,27 @@ where
 
     pub fn from_pq(p: &Uint<P>, q: &Uint<P>) -> Self {
         // N = pq
-        let n: Uint<M> = q.mul_wide(p).into();
+        let n: Uint<M> = q.split_mul(p).into();
         let pk = PK::from_n(&n);
 
         // phi = (q-1)(p-1)
         let phi: Uint<M> = q
             .wrapping_sub(&Uint::ONE)
-            .mul_wide(&p.wrapping_sub(&Uint::ONE))
+            .split_mul(&p.wrapping_sub(&Uint::ONE))
             .into();
 
         // inv_phi = phi^-1 mod N
-        let inv_phi = phi.inv_odd_mod(&pk.n).0;
+        let inv_phi = inv_mod_uint::<M>(&phi, pk.n.as_ref());
 
-        let pinv_q = p.inv_odd_mod(q).0;
+        let pinv_q = inv_mod_uint::<P>(p, q);
 
         let pp: Uint<M> = p.square_wide().into();
-        let pp_params = DynResidueParams::new(&pp);
-        let hp = Self::h(p, pp_params.modulus(), &n);
+        let pp_params = MontyParams::new(pp.to_odd().unwrap());
+        let hp = Self::h(p, pp_params.modulus().as_ref(), &n);
 
         let qq: Uint<M> = q.square_wide().into();
-        let qq_params = DynResidueParams::new(&qq);
-        let hq = Self::h(q, qq_params.modulus(), &n);
+        let qq_params = MontyParams::new(qq.to_odd().unwrap());
+        let hq = Self::h(q, qq_params.modulus().as_ref(), &n);
 
         SK {
             phi,
@@ -294,26 +324,23 @@ where
     }
 
     pub fn decrypt(&self, c: &RawCiphertext<C>) -> RawPlaintext<M> {
-        let c = DynResidue::new(&c.0, self.params);
+        let c = MontyForm::new(&c.0, self.params);
+        let n_wide = NonZero::new(self.n.as_ref().resize::<C>()).unwrap();
 
         // m = (c^phi mod N^2 - 1) / N
         let m: Uint<M> = c
-            .pow_bounded_exp(&self.phi.resize::<M>(), Uint::<M>::BITS)
+            .pow_bounded_exp(&self.phi, Uint::<M>::BITS)
             .retrieve()
             .wrapping_sub(&Uint::ONE)
-            .wrapping_div(&self.n.resize::<C>())
+            .wrapping_div(&n_wide)
             .resize(); // drop top half of the value
 
         // m = (m * phi^-1) mod N
 
         // m_mod_n = m mod N
-        let m_mod_n = m.const_rem(&self.n).0;
+        let m_mod_n = m.rem(&self.n);
 
-        // (lo, hi) = m_n * phi^-1
-        let (lo, hi) = m_mod_n.mul_wide(&self.inv_phi);
-
-        // final reduce by N, variable time by N, but it's public value
-        RawPlaintext(Uint::const_rem_wide((lo, hi), &self.n).0)
+        RawPlaintext(m_mod_n.mul_mod::<C>(&self.inv_phi, &self.n))
     }
 
     pub(crate) fn h(p: &Uint<P>, pp: &Uint<M>, n: &Uint<M>) -> Uint<P> {
@@ -330,52 +357,51 @@ where
         // =   1 - n         mod p^2
         //
 
-        let n_mod_pp = n.const_rem(pp).0; // should be fast because N and p^2 are close
-
-        Uint::ONE
+        let n_mod_pp = n.rem(&NonZero::new(*pp).unwrap()); // should be fast because N and p^2 are close
+        let p_wide = p.resize::<M>();
+        let p_wide_nz = NonZero::new(p_wide).unwrap();
+        let value = Uint::ONE
             .sub_mod(&n_mod_pp, pp)
             .wrapping_sub(&Uint::ONE) // L_p(x) = (x-1)/p
-            .wrapping_div(&p.resize()) // FIXME: var time on P
-            .inv_odd_mod_bounded(
-                &p.resize(),
-                Uint::<M>::BITS,
-                Uint::<P>::BITS,
-            )
-            .0
-            .resize() // dropping top half of bits
+            .wrapping_div(&p_wide_nz);
+
+        inv_mod_uint::<M>(&value, &p_wide).resize() // dropping top half of bits
     }
 
     fn mp(
         &self,
         cp: Uint<M>,
-        p: &Uint<P>,
+        p: &NonZero<Uint<P>>,
         hp: &Uint<P>,
-        param: &DynResidueParams<M>,
+        param: &MontyParams<M>,
     ) -> Uint<P> {
         // L_p(cp^{p-1} mod p^2) h_p mod p
-        let mp: Uint<P> = DynResidue::new(&cp, *param)
+        let p_wide_nz = NonZero::new(p.resize::<M>()).unwrap();
+        let mp: Uint<P> = MontyForm::new(&cp, *param)
             .pow_bounded_exp(
-                &p.wrapping_sub(&Uint::ONE).resize::<P>(),
+                &p.wrapping_sub(&Uint::ONE),
                 Uint::<P>::BITS,
             )
             .retrieve()
             .wrapping_sub(&Uint::ONE) // Lp(x) = (x-1)/p
-            .wrapping_div(&p.resize())
+            .wrapping_div(&p_wide_nz)
             .resize();
 
-        let x: Uint<P> = mp.const_rem(p).0;
+        let x: Uint<P> = mp.rem(p);
 
-        Uint::const_rem_wide(x.mul_wide(hp), p).0
+        x.mul_mod::<M>(hp, p)
     }
 
     pub fn decrypt_fast(&self, c: &RawCiphertext<C>) -> RawPlaintext<M> {
         let pp = self.pp_params.modulus();
         let qq = self.qq_params.modulus();
+        let p = NonZero::new(self.p).unwrap();
+        let q = NonZero::new(self.q).unwrap();
 
         let (cp, cq) = decompose(&c.0, pp, qq);
 
-        let mp = self.mp(cp, &self.p, &self.hp, &self.pp_params);
-        let mq = self.mp(cq, &self.q, &self.hq, &self.qq_params);
+        let mp = self.mp(cp, &p, &self.hp, &self.pp_params);
+        let mq = self.mp(cq, &q, &self.hq, &self.qq_params);
 
         RawPlaintext(recombine(&self.pinv_q, &mp, &mq, &self.p, &self.q))
     }
@@ -386,15 +412,15 @@ where
         init_params: &(
             Uint<P>,
             Uint<P>,
-            DynResidueParams<P>,
-            DynResidueParams<P>,
+            MontyParams<P>,
+            MontyParams<P>,
         ),
     ) -> Uint<M> {
         let (zp, zq) = decompose(z, &self.p, &self.q);
-        let rp = DynResidue::new(&zp, init_params.2)
+        let rp = MontyForm::new(&zp, init_params.2)
             .pow(&init_params.0)
             .retrieve();
-        let rq = DynResidue::new(&zq, init_params.3)
+        let rq = MontyForm::new(&zq, init_params.3)
             .pow(&init_params.1)
             .retrieve();
 
@@ -404,20 +430,21 @@ where
     // To reduce recalculation of constant params
     pub fn extract_n_root_init_params(
         &self,
-    ) -> (Uint<P>, Uint<P>, DynResidueParams<P>, DynResidueParams<P>) {
+    ) -> (Uint<P>, Uint<P>, MontyParams<P>, MontyParams<P>) {
         let dk_qminusone = self.q.wrapping_sub(&Uint::ONE);
         let dk_pminusone = self.p.wrapping_sub(&Uint::ONE);
-        let dk_dn = self.n.inv_mod(&self.phi).0;
+        let dk_dn = inv_mod_uint::<M>(self.n.as_ref(), &self.phi);
 
         let (dk_dp, dk_dq) = decompose(&dk_dn, &dk_pminusone, &dk_qminusone);
 
-        let p_params = DynResidueParams::new(&self.p);
-        let q_params = DynResidueParams::new(&self.q);
+        let p_params = MontyParams::new(self.p.to_odd().unwrap());
+        let q_params = MontyParams::new(self.q.to_odd().unwrap());
 
         (dk_dp, dk_dq, p_params, q_params)
     }
 }
 
+#[cfg(feature = "serde")]
 impl<const C: usize, const M: usize, const P: usize> SK<C, M, P>
 where
     Uint<P>: Bounded + Encoding,
@@ -430,13 +457,16 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<const C: usize, const M: usize, const P: usize> From<MinimalSK<P>>
     for SK<C, M, P>
 where
     Uint<P>: Bounded + Encoding,
     Uint<C>: Split<Output = Uint<M>>,
     Uint<C>: From<(Uint<M>, Uint<M>)>,
+    Uint<M>: Concat<Output = Uint<C>>,
     Uint<M>: From<(Uint<P>, Uint<P>)>,
+    Uint<P>: Concat<Output = Uint<M>>,
     Uint<M>: Encoding + Split<Output = Uint<P>>,
 {
     fn from(minimal: MinimalSK<P>) -> Self {
@@ -459,11 +489,16 @@ pub fn decompose<const C: usize, const M: usize>(
 ) -> (Uint<M>, Uint<M>)
 where
     Uint<C>: Split<Output = Uint<M>>,
+    Uint<C>: From<(Uint<M>, Uint<M>)>,
 {
-    let (hi, lo) = c.split();
+    let (lo, hi) = c.split();
 
-    let cp: Uint<M> = Uint::const_rem_wide((lo, hi), p).0;
-    let cq: Uint<M> = Uint::const_rem_wide((lo, hi), q).0;
+    let cp: Uint<M> = Uint::<C>::from((lo, hi))
+        .rem(&NonZero::new(p.resize::<C>()).unwrap())
+        .resize();
+    let cq: Uint<M> = Uint::<C>::from((lo, hi))
+        .rem(&NonZero::new(q.resize::<C>()).unwrap())
+        .resize();
 
     (cp, cq)
 }
@@ -477,7 +512,9 @@ pub fn recombine<const M: usize, const P: usize>(
     q: &Uint<P>,
 ) -> Uint<M>
 where
+    Uint<P>: Concat<Output = Uint<M>>,
     Uint<M>: From<(Uint<P>, Uint<P>)>,
+    Uint<M>: Split<Output = Uint<P>>,
 {
     // C_2 = p^-1 mod q
     // let c_2 = p.inv_odd_mod(q).0;
@@ -490,10 +527,10 @@ where
     let d = v2.sub_mod(&v1_less_q, q);
 
     // u = (v_2 - v_1) C_2 mod q
-    let u: Uint<P> = Uint::const_rem_wide(d.mul_wide(p_inv_q), q).0;
+    let u: Uint<P> = d.mul_mod::<M>(p_inv_q, &non_zero_q);
 
     // x = v_1 + u p
-    Uint::from(u.mul_wide(p)).wrapping_add(&v1.resize())
+    Uint::from(u.split_mul(p)).wrapping_add(&v1.resize())
 }
 
 impl<const C: usize, const M: usize> PK<C, M>
@@ -503,8 +540,8 @@ where
 {
     pub fn from_n(n: &Uint<M>) -> Self {
         // We generate N as half of L, so hi part of n.square_wide() is zero
-        let nn = n.square_wide().into();
-        let params = DynResidueParams::new(&nn);
+        let nn: Uint<C> = n.square_wide().into();
+        let params = MontyParams::<C>::new_vartime(nn.to_odd().unwrap());
 
         Self {
             n: NonZero::new(*n).unwrap(),
@@ -512,6 +549,7 @@ where
         }
     }
 
+    #[cfg(feature = "serde")]
     pub fn to_minimal(&self) -> MinimalPK<C, M>
     where
         Uint<M>: Bounded + Encoding,
@@ -525,7 +563,7 @@ where
     }
 
     pub fn get_nn(&self) -> &Uint<C> {
-        self.params.modulus()
+        self.params.modulus().as_ref()
     }
 
     pub fn gen_r(&self, rng: &mut impl CryptoRngCore) -> Uint<M> {
@@ -551,7 +589,7 @@ where
     }
 
     pub fn into_message(&self, m: &Uint<M>) -> Option<RawPlaintext<M>> {
-        m.lt(&self.n).then_some(RawPlaintext(*m))
+        m.lt(self.n.as_ref()).then_some(RawPlaintext(*m))
     }
 
     pub fn encrypt(
@@ -568,10 +606,10 @@ where
         m: &RawPlaintext<M>,
         r: &Uint<M>,
     ) -> RawCiphertext<C> {
-        let r = DynResidue::new(&r.resize(), self.params);
+        let r = MontyForm::new(&r.resize::<C>(), self.params);
 
         // r^N mod N^2
-        let r_pow_n = r.pow_bounded_exp(&self.n, self.n.bits_vartime());
+        let r_pow_n = r.pow_bounded_exp(self.n.as_ref(), self.n.as_ref().bits_vartime());
 
         //
         // g == (1 + N)
@@ -582,8 +620,8 @@ where
         //
         // 1 + m*N <= 1 + N^2 - N < N^2
         //
-        let g_pow_m = DynResidue::new(
-            &Uint::<C>::from(m.0.mul_wide(&self.n)).wrapping_add(&Uint::ONE),
+        let g_pow_m = MontyForm::new(
+            &Uint::<C>::from(m.0.split_mul(self.n.as_ref())).wrapping_add(&Uint::ONE),
             self.params,
         );
 
@@ -598,8 +636,8 @@ where
         c_2: &RawCiphertext<C>,
     ) -> RawCiphertext<C> {
         // c_1 * c_2 mod N^2
-        let c_1 = DynResidue::new(&c_1.0, self.params);
-        let c_2 = DynResidue::new(&c_2.0, self.params);
+        let c_1 = MontyForm::new(&c_1.0, self.params);
+        let c_2 = MontyForm::new(&c_2.0, self.params);
 
         RawCiphertext(c_1.mul(&c_2).retrieve())
     }
@@ -610,7 +648,7 @@ where
         m: &RawPlaintext<M>,
     ) -> RawCiphertext<C> {
         // c = c^m mod N^2
-        let c = DynResidue::new(&c.0, self.params).pow(&m.0).retrieve();
+        let c = MontyForm::new(&c.0, self.params).pow(&m.0).retrieve();
 
         RawCiphertext(c)
     }
@@ -623,8 +661,8 @@ where
         let bits = m.0.bits_vartime();
 
         // c = c^m mod N^2
-        let c = DynResidue::new(&c.0, self.params)
-            .pow_bounded_exp(&m.0.resize::<M>(), bits)
+        let c = MontyForm::new(&c.0, self.params)
+            .pow_bounded_exp(&m.0, bits)
             .retrieve();
 
         RawCiphertext(c)
@@ -637,7 +675,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use quickcheck::quickcheck;
 
     use super::*;

--- a/crates/sl-paillier/src/lib.rs
+++ b/crates/sl-paillier/src/lib.rs
@@ -883,8 +883,9 @@ mod tests {
         assert_eq!(s1, s2);
         assert_eq!(p1, p2);
 
-        let s1b = bincode::serialize(&sk).unwrap();
-        let sk1: SK2048 = bincode::deserialize(&s1b).unwrap();
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&sk, &mut bytes).unwrap();
+        let sk1: SK2048 = ciborium::from_reader(bytes.as_slice()).unwrap();
         assert_eq!(sk.to_minimal(), sk1.to_minimal());
     }
 }

--- a/crates/sl-paillier/src/traits.rs
+++ b/crates/sl-paillier/src/traits.rs
@@ -3,7 +3,7 @@
 
 use rand_core::CryptoRngCore;
 
-use crypto_bigint::modular::runtime_mod::DynResidueParams;
+use crypto_bigint::modular::MontyParams;
 use crypto_bigint::{Encoding, NonZero, RandomMod, Uint};
 
 pub trait PublicN<const L: usize>
@@ -25,5 +25,5 @@ where
 }
 
 pub trait PublicModParams<const L: usize> {
-    fn params(&self) -> DynResidueParams<L>;
+    fn params(&self) -> MontyParams<L>;
 }

--- a/crates/sl-verifiable-enc/src/lib.rs
+++ b/crates/sl-verifiable-enc/src/lib.rs
@@ -673,6 +673,11 @@ pub trait ExtractBit: Index<usize, Output = u8> {
 
     /// Get the length of the byte array.
     fn len(&self) -> usize;
+
+    /// Check whether the byte array is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<const N: usize> ExtractBit for [u8; N] {

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,77 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2025-0141",
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "LicenseRef-Silence-Labs",
+    "MIT",
+    "Unicode-3.0",
+]
+
+[[licenses.clarify]]
+crate = "sl-compute-common"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-messages"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-mpc-mate"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-mpc-traits"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-oblivious"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-paillier"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-shamir"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[[licenses.clarify]]
+crate = "sl-verifiable-enc"
+expression = "LicenseRef-Silence-Labs"
+license-files = [
+    { path = "../../LICENSE", hash = 0x44125835 },
+]
+
+[bans]
+skip = [
+    "crypto-bigint",
+    "serdect",
+    "windows-sys",
+]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+publish = false
+rust-version = "1.88"
+license = "Apache-2.0"
+
+[dependencies]
+serde_json = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,498 @@
+// Copyright 2026 Silence Laboratories Pte. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::BTreeSet,
+    env,
+    path::PathBuf,
+    process::{Command, ExitCode},
+};
+
+use serde_json::Value;
+
+struct FeatureMatrixArgs {
+    command: String,
+    packages: Vec<String>,
+    dry_run: bool,
+    cargo_args: Vec<String>,
+}
+
+fn main() -> ExitCode {
+    match try_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn try_main() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    match args.next().as_deref() {
+        Some("feature-matrix") => run_feature_matrix(args.collect()),
+        _ => Err(usage()),
+    }
+}
+
+fn run_feature_matrix(args: Vec<String>) -> Result<(), String> {
+    let args = parse_feature_matrix_args(args)?;
+    let workspace_root = workspace_root()?;
+    let metadata = cargo_metadata(&workspace_root)?;
+    let all_packages = workspace_packages(&metadata)?;
+    let selected_packages = select_packages(all_packages, &args.packages)?;
+
+    let mut command_count = 0usize;
+    for package in selected_packages {
+        for (label, feature_args) in feature_combinations(&package)? {
+            let cargo_command = cargo_command(
+                &args.command,
+                &package.name,
+                &feature_args,
+                &args.cargo_args,
+            );
+            println!("==> {} [{}]", package.name, label);
+            println!("{}", join_command(&cargo_command));
+            command_count += 1;
+
+            if !args.dry_run {
+                let status = Command::new(&cargo_command[0])
+                    .args(&cargo_command[1..])
+                    .current_dir(&workspace_root)
+                    .status()
+                    .map_err(|err| {
+                        format!(
+                            "failed to run {}: {err}",
+                            join_command(&cargo_command)
+                        )
+                    })?;
+
+                if !status.success() {
+                    return Err(format!(
+                        "command failed with status {}: {}",
+                        status,
+                        join_command(&cargo_command)
+                    ));
+                }
+            }
+        }
+    }
+
+    println!("Executed {command_count} command(s).");
+
+    Ok(())
+}
+
+fn usage() -> String {
+    "usage: cargo run -p xtask -- feature-matrix <clippy|test> [--package <name> ...] [--dry-run] [-- <cargo args...>]"
+        .to_owned()
+}
+
+fn parse_feature_matrix_args(
+    args: Vec<String>,
+) -> Result<FeatureMatrixArgs, String> {
+    let mut command = None;
+    let mut packages = Vec::new();
+    let mut dry_run = false;
+    let mut cargo_args = Vec::new();
+
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "clippy" | "test" if command.is_none() => command = Some(arg),
+            "--package" => {
+                let package = iter.next().ok_or_else(|| {
+                    "--package requires a package name".to_owned()
+                })?;
+                packages.push(package);
+            }
+            "--dry-run" => dry_run = true,
+            "--" => {
+                cargo_args.extend(iter);
+                break;
+            }
+            _ => return Err(usage()),
+        }
+    }
+
+    Ok(FeatureMatrixArgs {
+        command: command.ok_or_else(usage)?,
+        packages,
+        dry_run,
+        cargo_args,
+    })
+}
+
+fn workspace_root() -> Result<PathBuf, String> {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(PathBuf::from)
+        .ok_or_else(|| "failed to determine workspace root".to_owned())
+}
+
+fn cargo_metadata(workspace_root: &PathBuf) -> Result<Value, String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(workspace_root)
+        .output()
+        .map_err(|err| format!("failed to run cargo metadata: {err}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed with status {}",
+            output.status
+        ));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|err| format!("failed to parse cargo metadata JSON: {err}"))
+}
+
+#[derive(Clone)]
+struct Package {
+    name: String,
+    features: Vec<String>,
+    default_features: Vec<String>,
+}
+
+fn implicit_optional_dependency_features(
+    package: &Value,
+    feature_map: &serde_json::Map<String, Value>,
+) -> BTreeSet<String> {
+    let optional_dependencies = package["dependencies"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|dependency| dependency["optional"].as_bool() == Some(true))
+        .filter_map(|dependency| dependency["name"].as_str())
+        .collect::<BTreeSet<_>>();
+
+    feature_map
+        .iter()
+        .filter_map(|(feature, members)| {
+            let members = members.as_array()?;
+            if members.len() != 1 {
+                return None;
+            }
+
+            let member = members[0].as_str()?;
+            (member == format!("dep:{feature}")
+                && optional_dependencies.contains(feature.as_str()))
+            .then(|| feature.clone())
+        })
+        .collect()
+}
+
+fn workspace_packages(metadata: &Value) -> Result<Vec<Package>, String> {
+    let workspace_members = metadata["workspace_members"]
+        .as_array()
+        .ok_or_else(|| {
+            "cargo metadata is missing workspace_members".to_owned()
+        })?
+        .iter()
+        .filter_map(Value::as_str)
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>();
+
+    let mut packages = metadata["packages"]
+        .as_array()
+        .ok_or_else(|| "cargo metadata is missing packages".to_owned())?
+        .iter()
+        .filter_map(|package| {
+            let id = package["id"].as_str()?;
+            if !workspace_members.contains(id) {
+                return None;
+            }
+
+            let name = package["name"].as_str()?.to_owned();
+            let feature_map = package["features"].as_object()?;
+            let implicit_optional_features =
+                implicit_optional_dependency_features(package, feature_map);
+            let mut features = feature_map
+                .keys()
+                .filter(|feature| feature.as_str() != "default")
+                .filter(|feature| {
+                    !implicit_optional_features.contains(feature.as_str())
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            features.sort();
+
+            let mut default_features = feature_map
+                .get("default")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .filter(|feature| {
+                    !implicit_optional_features.contains(*feature)
+                })
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>();
+            default_features.sort();
+
+            Some(Package {
+                name,
+                features,
+                default_features,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    packages.sort_by(|left, right| left.name.cmp(&right.name));
+
+    Ok(packages)
+}
+
+fn select_packages(
+    all_packages: Vec<Package>,
+    names: &[String],
+) -> Result<Vec<Package>, String> {
+    if names.is_empty() {
+        return Ok(all_packages);
+    }
+
+    let requested = names.iter().cloned().collect::<BTreeSet<_>>();
+    let selected = all_packages
+        .into_iter()
+        .filter(|package| requested.contains(&package.name))
+        .collect::<Vec<_>>();
+
+    let found = selected
+        .iter()
+        .map(|package| package.name.clone())
+        .collect::<BTreeSet<_>>();
+    let missing = requested.difference(&found).cloned().collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(format!(
+            "unknown workspace package(s): {}",
+            missing.join(", ")
+        ));
+    }
+
+    Ok(selected)
+}
+
+fn feature_combinations(
+    package: &Package,
+) -> Result<Vec<(String, Vec<String>)>, String> {
+    let default_selectable = package
+        .default_features
+        .iter()
+        .filter(|feature| package.features.contains(*feature))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut combinations = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    add_combination(
+        &mut combinations,
+        &mut seen,
+        "default".to_owned(),
+        Vec::new(),
+    );
+
+    if package.default_features.is_empty() {
+        for subset in subsets(&package.features) {
+            if subset.is_empty() {
+                continue;
+            }
+            let label = subset.join(",");
+            let args = vec!["--features".to_owned(), label.clone()];
+            add_combination(&mut combinations, &mut seen, label, args);
+        }
+        return Ok(combinations);
+    }
+
+    add_combination(
+        &mut combinations,
+        &mut seen,
+        "no-default".to_owned(),
+        vec!["--no-default-features".to_owned()],
+    );
+
+    for subset in subsets(&package.features) {
+        if subset.is_empty() {
+            continue;
+        }
+        let joined = subset.join(",");
+        add_combination(
+            &mut combinations,
+            &mut seen,
+            format!("no-default+{joined}"),
+            vec![
+                "--no-default-features".to_owned(),
+                "--features".to_owned(),
+                joined,
+            ],
+        );
+    }
+
+    let default_extras = package
+        .features
+        .iter()
+        .filter(|feature| !default_selectable.contains(feature.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    for subset in subsets(&default_extras) {
+        if subset.is_empty() {
+            continue;
+        }
+        let joined = subset.join(",");
+        add_combination(
+            &mut combinations,
+            &mut seen,
+            format!("default+{joined}"),
+            vec!["--features".to_owned(), joined],
+        );
+    }
+
+    Ok(combinations)
+}
+
+fn add_combination(
+    combinations: &mut Vec<(String, Vec<String>)>,
+    seen: &mut BTreeSet<Vec<String>>,
+    label: String,
+    args: Vec<String>,
+) {
+    if seen.insert(args.clone()) {
+        combinations.push((label, args));
+    }
+}
+
+fn subsets(items: &[String]) -> Vec<Vec<String>> {
+    let count = 1usize << items.len();
+    let mut subsets = Vec::with_capacity(count);
+
+    for mask in 0..count {
+        let mut subset = Vec::new();
+        for (index, item) in items.iter().enumerate() {
+            if (mask & (1usize << index)) != 0 {
+                subset.push(item.clone());
+            }
+        }
+        subsets.push(subset);
+    }
+
+    subsets
+}
+
+fn cargo_command(
+    command: &str,
+    package: &str,
+    feature_args: &[String],
+    cargo_args: &[String],
+) -> Vec<String> {
+    let mut args = vec![
+        "cargo".to_owned(),
+        command.to_owned(),
+        "--package".to_owned(),
+        package.to_owned(),
+    ];
+
+    args.extend(feature_args.iter().cloned());
+    args.extend(cargo_args.iter().cloned());
+
+    if command == "clippy" {
+        args.push("--".to_owned());
+        args.push("-D".to_owned());
+        args.push("warnings".to_owned());
+    }
+
+    args
+}
+
+fn join_command(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| {
+            if arg.chars().all(|ch| {
+                ch.is_ascii_alphanumeric() || "-_.,/=:".contains(ch)
+            }) {
+                arg.clone()
+            } else {
+                format!("{arg:?}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_feature_matrix_args_collects_cargo_args_after_separator() {
+        let args = parse_feature_matrix_args(vec![
+            "test".to_owned(),
+            "--package".to_owned(),
+            "sl-paillier".to_owned(),
+            "--dry-run".to_owned(),
+            "--".to_owned(),
+            "--release".to_owned(),
+            "--locked".to_owned(),
+        ])
+        .unwrap();
+
+        assert_eq!(args.command, "test");
+        assert_eq!(args.packages, vec!["sl-paillier"]);
+        assert!(args.dry_run);
+        assert_eq!(args.cargo_args, vec!["--release", "--locked"]);
+    }
+
+    #[test]
+    fn cargo_command_places_forwarded_args_before_clippy_lints() {
+        let command = cargo_command(
+            "clippy",
+            "xtask",
+            &["--features".to_owned(), "serde".to_owned()],
+            &["--release".to_owned()],
+        );
+
+        assert_eq!(
+            command,
+            vec![
+                "cargo",
+                "clippy",
+                "--package",
+                "xtask",
+                "--features",
+                "serde",
+                "--release",
+                "--",
+                "-D",
+                "warnings",
+            ]
+        );
+    }
+
+    #[test]
+    fn filters_implicit_optional_dependency_features() {
+        let package = serde_json::json!({
+            "dependencies": [
+                { "name": "tokio", "optional": true },
+                { "name": "fastwebsockets", "optional": true },
+                { "name": "serde", "optional": false }
+            ],
+            "features": {
+                "default": [],
+                "tokio": ["dep:tokio"],
+                "fastwebsockets": ["dep:fastwebsockets"],
+                "mux": ["tokio/macros", "tokio/rt"],
+                "fast-ws": ["fastwebsockets", "tokio/macros"]
+            }
+        });
+
+        let feature_map = package["features"].as_object().unwrap();
+        let implicit =
+            implicit_optional_dependency_features(&package, feature_map);
+
+        assert_eq!(
+            implicit,
+            BTreeSet::from(["fastwebsockets".to_owned(), "tokio".to_owned()])
+        );
+    }
+}


### PR DESCRIPTION
- fix the sl-messages mux test and the sl-messages build/test failure with `-F mux`
- add GitHub Actions CI for fmt, cargo-deny, clippy, and tests
- add an xtask crate to run clippy/test across workspace feature combinations
- configure cargo-deny for ignored advisories, custom workspace licenses, and accepted duplicate dependencies
- migrate sl-paillier to crypto-bigint 0.6 / crypto-primes 0.6 and update bigint, montgomery, benchmark, and trait code accordingly
- remove secret-side _vartime usage from sl-paillier private-key paths
- add changelog entries for sl-messages and sl-paillier