### PR TITLE
ci(ci): update github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Install Rust toolchain
         run: rustup toolchain install 1.88 --profile minimal --component rustfmt
       - name: Use Rust 1.88
@@ -30,13 +30,13 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Install Rust toolchain
         run: rustup toolchain install 1.88 --profile minimal
       - name: Use Rust 1.88
         run: rustup default 1.88
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.81.1
         with:
           tool: cargo-deny
       - name: Run cargo deny
@@ -45,7 +45,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Install Rust toolchain
         run: rustup toolchain install 1.88 --profile minimal --component clippy
       - name: Use Rust 1.88
@@ -56,7 +56,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Install Rust toolchain
         run: rustup toolchain install 1.88 --profile minimal
       - name: Use Rust 1.88


### PR DESCRIPTION
Update `actions/checkout` to v6.0.2 and `taiki-e/install-action` to v2.81.1 in the CI workflow to ensure the use of recent action versions.