### PR TITLE
fix(sl-oblivious): enable sl-transcript default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,4 @@ tokio = { version = "1.44", default-features = false }
 x25519-dalek = { version = "2.0.0", default-features = false }
 zeroize = { version = "1.6", default-features = false }
 
-sl-transcript = { path = "crates/sl-transcript", version = "0.1.0-pre.2", default-features = false }
+sl-transcript = { path = "crates/sl-transcript", version = "0.1.0-pre.2" }


### PR DESCRIPTION
## Problem

Docs generation on kellnr fails for crates that pull `sl-oblivious` (e.g. `simple-setup-msg`):

```
error[E0432]: unresolved import `sl_transcript::Transcript` (×5)
error: could not compile `sl-oblivious` (lib) due to 5 previous errors
Failed to extract docs from crate: Cargo error: 1 job failed
```

## Root cause

- `sl-transcript` exports `Transcript` only under the `merlin`/`shake128` features (`default = ["merlin"]`).
- The workspace pinned `sl-transcript` with `default-features = false`.
- `sl-oblivious` uses `sl_transcript::{Transcript, TranscriptProtocol}` unconditionally in its core modules.
- When a downstream crate (e.g. `dkls23` → `simple-setup-msg`) consumes `sl-oblivious`/`sl-transcript` with `default-features = false`, neither enables a transcript backend → `Transcript` is missing → E0432.

## Fix

Restore `sl-transcript`'s intended default feature in the workspace definition. A transcript backend (`merlin`) is then always available to `sl-oblivious` regardless of downstream feature selection.

## Verification

Reproduced the exact failure inside the kellnr container (`cargo check -p sl-oblivious --no-default-features` → 5× E0432) and confirmed it compiles cleanly after the change, including the strictest scenario where both `sl-oblivious` and `sl-transcript` are consumed with `default-features = false`.