### PR TITLE
Fix WebSocket payload conversion for all message variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/crates/sl-messages/src/ws.rs
+++ b/crates/sl-messages/src/ws.rs
@@ -113,16 +113,14 @@ impl FastRelay {
                         Payload::Bytes(msg) => msg,
 
                         Payload::Owned(vec) => {
-                            // There is no direct way to build
-                            // BytesMut from Vec<u8>.  But we can
-                            // create Bytes::from(vec)
-                            let bytes = Bytes::from(vec);
-
-                            // and then convert Bytes to BytesMut
-                            bytes.try_into_mut().unwrap()
+                            BytesMut::from(Bytes::from(vec))
                         }
 
-                        payload => BytesMut::from(&*payload),
+                        Payload::BorrowedMut(payload) => {
+                            BytesMut::from(&*payload)
+                        }
+
+                        Payload::Borrowed(payload) => BytesMut::from(payload),
                     };
 
                     if tx.send(msg).await.is_err() {


### PR DESCRIPTION
Handle owned, borrowed, and mutably borrowed payloads explicitly when converting WebSocket messages to `BytesMut`.

Also update dependencies:
- yanked spin 0.9.8
- vulnerability in crossbeam-epoch 0.9.18