### PR TITLE
fix(sl-oblivious): enable sl-transcript default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,4 @@ tokio = { version = "1.44", default-features = false }
 x25519-dalek = { version = "2.0.0", default-features = false }
 zeroize = { version = "1.6", default-features = false }
 
-sl-transcript = { path = "crates/sl-transcript", version = "0.1.0-pre.2", default-features = false }
+sl-transcript = { path = "crates/sl-transcript", version = "0.1.0-pre.2" }


### PR DESCRIPTION
## Description

Enable default features for the `sl-transcript` dependency in the workspace root `Cargo.toml`.

This is the change from PR #37 (merged into the `sl-transcript` branch) re-applied on top of `main`, so it isn't lost when that branch is deleted.
