### PR TITLE
chore(security): add Dependabot cooldown for cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add `.github/dependabot.yml` (cargo + github-actions) with `cooldown: default-days: 7`.

Cargo has no native min-publish-age on stable (RFC #3923, nightly only), so Dependabot cooldown is the equivalent defense.

Ref: DevOps_instructions#45